### PR TITLE
Refactor to modular src layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,3 +197,4 @@
    - Equity summary CSV (`logs/wfv_summary/ProdA_equity_summary.csv`) exists and shows plausible P&L per fold  
 
 ---
+- New modular code in ./src (config, data_loader, features, strategy, main).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # phiradon168
 phiradon168 Ai stategy systeM168
+\nThis version refactors the original script into modular components located in the src directory.

--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,6 @@
 changelog.md
+### 2024-06-02
+- [Patch v4.9.0] Refactor into modular src
+- New/Updated unit tests added for src modules
+- QA: pytest -q passed (4 tests)
+

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,35 @@
+"""Configuration module for phiradon168."""
+
+import logging
+import os
+from datetime import datetime
+
+# CSV data paths
+CSV_PATH_M1 = "/content/drive/MyDrive/Phiradon168/XAUUSD_M1.csv"
+CSV_PATH_M15 = "/content/drive/MyDrive/Phiradon168/XAUUSD_M15.csv"
+
+# Logs directory
+LOG_DIR = "/content/drive/MyDrive/Phiradon168/logs"
+
+# Ensure log directory exists
+os.makedirs(LOG_DIR, exist_ok=True)
+
+# Log file name with timestamp for uniqueness
+LOG_FILENAME = os.path.join(LOG_DIR, f"gold_ai_{datetime.now():%Y%m%d_%H%M%S}.log")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[
+        logging.FileHandler(LOG_FILENAME, mode="w", encoding="utf-8"),
+        logging.StreamHandler()
+    ],
+)
+
+__all__ = [
+    "CSV_PATH_M1",
+    "CSV_PATH_M15",
+    "LOG_DIR",
+    "LOG_FILENAME",
+]

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,0 +1,19 @@
+"""Data loading utilities."""
+
+from typing import Tuple
+import pandas as pd
+
+from .config import CSV_PATH_M1, CSV_PATH_M15
+
+
+def load_data() -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Load M1 and M15 CSV data.
+
+    Returns:
+        Tuple containing M1 dataframe and M15 dataframe.
+    """
+    df_m1 = pd.read_csv(CSV_PATH_M1)
+    df_m15 = pd.read_csv(CSV_PATH_M15)
+    return df_m1, df_m15
+
+__all__ = ["load_data"]

--- a/src/features.py
+++ b/src/features.py
@@ -1,0 +1,14 @@
+"""Feature engineering utilities."""
+
+import pandas as pd
+
+
+def add_simple_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Add simple moving average feature to dataframe."""
+    if "Close" not in df.columns:
+        raise KeyError("Column 'Close' not found in dataframe")
+    df = df.copy()
+    df["sma_5"] = df["Close"].rolling(window=5).mean()
+    return df
+
+__all__ = ["add_simple_features"]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,15 @@
+"""Main entry point for phiradon168 strategy."""
+
+import logging
+from .data_loader import load_data
+from .strategy import simple_strategy
+
+
+def run():
+    df_m1, _ = load_data()
+    buys, sells = simple_strategy(df_m1)
+    logging.info(f"Executed simple strategy: buys={buys}, sells={sells}")
+
+
+if __name__ == "__main__":
+    run()

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -1,0 +1,22 @@
+"""Basic strategy implementation."""
+
+from typing import Tuple
+import pandas as pd
+
+from .features import add_simple_features
+
+
+def simple_strategy(df: pd.DataFrame) -> Tuple[int, int]:
+    """Run a naive strategy based on moving average crossover.
+
+    Returns:
+        Tuple of (number_of_buys, number_of_sells)
+    """
+    df = add_simple_features(df)
+    buys = ((df["Close"] > df["sma_5"]).shift(1) & (df["Close"] <= df["sma_5"]))
+    sells = ((df["Close"] < df["sma_5"]).shift(1) & (df["Close"] >= df["sma_5"]))
+    num_buys = buys.sum()
+    num_sells = sells.sum()
+    return int(num_buys), int(num_sells)
+
+__all__ = ["simple_strategy"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+# Ensure project root is on sys.path for module imports
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT_DIR)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,7 @@
+import src.config as config
+
+
+def test_paths():
+    assert config.CSV_PATH_M1 == "/content/drive/MyDrive/Phiradon168/XAUUSD_M1.csv"
+    assert config.CSV_PATH_M15 == "/content/drive/MyDrive/Phiradon168/XAUUSD_M15.csv"
+    assert config.LOG_DIR == "/content/drive/MyDrive/Phiradon168/logs"

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pytest
+import importlib
+import src.data_loader as data_loader
+
+
+def test_load_data(monkeypatch):
+    # Create temporary CSV files
+    df = pd.DataFrame({'Close': [1, 2, 3, 4, 5]})
+    tmp_m1 = 'tmp_m1.csv'
+    tmp_m15 = 'tmp_m15.csv'
+    df.to_csv(tmp_m1, index=False)
+    df.to_csv(tmp_m15, index=False)
+
+    monkeypatch.setattr(data_loader, 'CSV_PATH_M1', tmp_m1, raising=False)
+    monkeypatch.setattr(data_loader, 'CSV_PATH_M15', tmp_m15, raising=False)
+
+    df1, df2 = data_loader.load_data()
+    assert df1.equals(df)
+    assert df2.equals(df)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,10 @@
+import pandas as pd
+import pytest
+from src.features import add_simple_features
+
+
+def test_add_simple_features():
+    df = pd.DataFrame({'Close': [1, 2, 3, 4, 5]})
+    result = add_simple_features(df)
+    assert 'sma_5' in result.columns
+    assert result['sma_5'].iloc[4] == pytest.approx(3.0)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,9 @@
+import pandas as pd
+from src.strategy import simple_strategy
+
+
+def test_simple_strategy():
+    df = pd.DataFrame({'Close': [1, 2, 3, 2, 1, 2, 3]})
+    buys, sells = simple_strategy(df)
+    assert isinstance(buys, int)
+    assert isinstance(sells, int)


### PR DESCRIPTION
## Summary
- extract config, data_loader, features, strategy and main modules under `src`
- update AGENTS and changelog
- add unit tests for new modules
- mention modular layout in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dcb25db0c8325b1528532aae73209