### PR TITLE
[Patch v1.2.0] Ensure ENTRY_CONFIG_PER_FOLD fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,8 @@
 - [Patch v1.0.1] Update default paths for data and logs
 - New/Updated unit tests added for imports
 - QA: pytest -q passed (1 tests)
+
+### 2025-06-02
+- [Patch v1.2.0] Ensure ENTRY_CONFIG_PER_FOLD fallback
+- New/Updated unit tests added for src.main
+- QA: pytest -q passed (3 tests)

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,14 @@
 import logging
 import os
 import sys
+
+# --------------------------------------------
+# นำเข้า `ENTRY_CONFIG_PER_FOLD` จาก `config.py` ให้กลายเป็น `DEFAULT_ENTRY_CONFIG_PER_FOLD`
+try:
+    from .config import ENTRY_CONFIG_PER_FOLD as DEFAULT_ENTRY_CONFIG_PER_FOLD
+except ImportError:
+    DEFAULT_ENTRY_CONFIG_PER_FOLD = {}
+# --------------------------------------------
 import time
 import pandas as pd
 import shutil # For file moving in pipeline mode
@@ -317,8 +325,12 @@ try:
     permutation_importance_threshold
 except NameError:
     permutation_importance_threshold = DEFAULT_PERMUTATION_IMPORTANCE_THRESHOLD
+#
+# ถ้า `ENTRY_CONFIG_PER_FOLD` ยังไม่ถูกกำหนดในโมดูลนี้
+# ให้ใช้ `DEFAULT_ENTRY_CONFIG_PER_FOLD` (หรือ `{}` กรณี import ไม่สำเร็จ)
+#
 try:
-    ENTRY_CONFIG_PER_FOLD # Referenced in main
+    ENTRY_CONFIG_PER_FOLD  # อ้างอิงใน main
 except NameError:
     ENTRY_CONFIG_PER_FOLD = DEFAULT_ENTRY_CONFIG_PER_FOLD
 try:

--- a/tests/test_entry_config_fallback.py
+++ b/tests/test_entry_config_fallback.py
@@ -1,0 +1,26 @@
+import importlib
+import types
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+
+
+def test_entry_config_import_error(monkeypatch):
+    # Import src.main normally; config import should fail due to missing deps
+    if 'src.main' in sys.modules:
+        del sys.modules['src.main']
+    main = importlib.import_module('src.main')
+    assert main.DEFAULT_ENTRY_CONFIG_PER_FOLD == {}
+
+
+def test_entry_config_loaded_from_config(monkeypatch):
+    dummy = types.ModuleType('config')
+    dummy.ENTRY_CONFIG_PER_FOLD = {'x': 1}
+    monkeypatch.setitem(sys.modules, 'src.config', dummy)
+    if 'src.main' in sys.modules:
+        del sys.modules['src.main']
+    main = importlib.import_module('src.main')
+    assert main.DEFAULT_ENTRY_CONFIG_PER_FOLD == {'x': 1}


### PR DESCRIPTION
## Summary
- load `ENTRY_CONFIG_PER_FOLD` from config if possible
- fallback to an empty dict when config import fails
- add tests for ENTRY_CONFIG_PER_FOLD defaults
- document patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dd86c3db0832599b4d6764591ca24