### PR TITLE
[Patch v4.8.3] fix setup_output_directory import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,8 @@
 - [Patch v1.2.0] Ensure ENTRY_CONFIG_PER_FOLD fallback
 - New/Updated unit tests added for src.main
 - QA: pytest -q passed (3 tests)
+
+### 2025-06-03
+- [Patch v4.8.3] Import setup_output_directory in main
+- New/Updated unit tests added for src.main
+- QA: pytest -q passed (4 tests)

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -38,7 +38,10 @@ import gzip
 import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 from IPython import get_ipython
-import requests
+try:
+    import requests
+except ImportError:  # pragma: no cover - optional dependency for certain features
+    requests = None
 import datetime # <<< ENSURED Standard import 'import datetime'
 
 # --- Helper for Safe Global Access (Defined *before* use in other parts) ---

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,10 @@ except ImportError:
     DEFAULT_ENTRY_CONFIG_PER_FOLD = {}
 # --------------------------------------------
 import time
+try:
+    from data_loader import setup_output_directory  # <<< [Patch v4.8.3] Import to resolve NameError >>>
+except ImportError:  # pragma: no cover - fallback for package import
+    from .data_loader import setup_output_directory
 import pandas as pd
 import shutil # For file moving in pipeline mode
 import traceback

--- a/tests/test_setup_output_directory_import.py
+++ b/tests/test_setup_output_directory_import.py
@@ -1,0 +1,11 @@
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+def test_setup_output_directory_is_imported():
+    if 'src.main' in sys.modules:
+        del sys.modules['src.main']
+    main = importlib.import_module('src.main')
+    assert hasattr(main, 'setup_output_directory')


### PR DESCRIPTION
## Summary
- import `setup_output_directory` from `data_loader` into `main`
- make `requests` optional in `data_loader` to avoid ModuleNotFoundError
- add regression test for the new import
- update CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dda88205c83259b04d7a43eea8d0d