### PR TITLE
Fix safe_set_datetime import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@
 - [Patch v4.8.5] Fix offline execution for ProjectP
 - New/Updated unit tests added for src.main
 - QA: pytest -q passed (4 tests)
+
+### 2025-06-02
+- [Patch v4.8.8] Add import for safe_set_datetime in strategy.py
+- QA: pytest -q passed (6 tests)

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -13,6 +13,11 @@ import time
 import json
 import pandas as pd
 import numpy as np
+# [Patch v4.8.8] Import safe_set_datetime from data_loader with fallback
+try:
+    from data_loader import safe_set_datetime
+except ImportError:  # pragma: no cover - fallback when imported as package
+    from .data_loader import safe_set_datetime
 from .data_loader import safe_get_global  # [Patch] ensure availability when imported as package
 import traceback
 from joblib import dump as joblib_dump # Use joblib dump directly


### PR DESCRIPTION
## Summary
- fix strategy import for `safe_set_datetime`
- log entry in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683de3b0892c8325a531cdb84d66d627