### PR TITLE
Fix ModuleNotFoundError for src submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,6 @@
 - QA: pytest -q passed (7 tests)
 
 
+### 2025-06-03
+- [Patch v4.8.9] Fix ModuleNotFoundError for src submodules
+- QA: pytest -q passed (7 tests)

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 from src.main import main
 
 if __name__ == '__main__':

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# (empty file for package recognition)


### PR DESCRIPTION
## Notes
- Added runtime PYTHONPATH patching in `ProjectP.py`
- Documented `src/__init__.py` as empty package marker

## Summary
- Append `src` to `sys.path` before importing `src.main`
- Include comment noting empty init file
- Changelog updated with passing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683df35788e48325aa0d0dbbc2b915a7