### PR TITLE
Patch v4.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,8 @@
 - New/Updated unit tests added for src.main and src.config
 
 - QA: pytest -q passed (7 tests)
+
+### 2025-06-03
+- [Patch v4.8.12] Ensure single TA install and warn on drive mount failure
+- New/Updated unit tests added for src.config
+- QA: pytest -q passed (8 tests)

--- a/tests/test_ta_install.py
+++ b/tests/test_ta_install.py
@@ -1,0 +1,21 @@
+import importlib
+import types
+import sys
+import os
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'src'))
+
+
+def test_ensure_ta_installed(monkeypatch):
+    dummy_ta = types.ModuleType('ta')
+    dummy_ta.__version__ = '0.test'
+    monkeypatch.setitem(sys.modules, 'ta', dummy_ta)
+    monkeypatch.setitem(sys.modules, 'seaborn', types.ModuleType('seaborn'))
+    monkeypatch.setitem(sys.modules, 'requests', types.ModuleType('requests'))
+    monkeypatch.setitem(sys.modules, 'shap', types.ModuleType('shap'))
+    if 'src.config' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'src.config', raising=False)
+    config = importlib.import_module('src.config')
+    assert config.TA_VERSION == '0.test'


### PR DESCRIPTION
## Notes
- เพิ่มฟังก์ชัน `_ensure_ta_installed` เพื่อให้ติดตั้งไลบรารี `ta` เพียงครั้งเดียว
- ปรับขั้นตอน mount Google Drive ให้บันทึกเพียงคำเตือนเมื่อผิดพลาด
- เพิ่ม unit test สำหรับฟังก์ชันติดตั้ง `ta`

## Summary
- ติดตั้ง `ta` ครั้งเดียวและบันทึกเวอร์ชันอย่างปลอดภัย
- ลดระดับความผิดพลาดของการ mount Google Drive เป็นคำเตือนเดียว
- ทดสอบใหม่ทั้งหมดผ่าน `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683dfb6e59508325b26a7fd074483dc5