### PR TITLE
[Patch v4.9.0] Vectorize session tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,8 @@
 - QA: pytest -q passed (13 tests)
 
 
+### 2025-06-05
+- [Patch v4.9.0] ปรับปรุงการสร้างคอลัมน์ session ให้เป็นแบบ Vectorized และลดการวนลูปแถว
+- New/Updated unit tests added for src.features
+- QA: pytest -q passed (16 tests)
+

--- a/tests/test_session_tag.py
+++ b/tests/test_session_tag.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import src.features as features
+
+
+def test_get_session_tag_basic():
+    ts = pd.Timestamp('2024-01-01 07:00', tz='UTC')
+    assert features.get_session_tag(ts) == 'Asia/London'
+
+
+def test_engineer_session_vectorized_distribution():
+    idx = pd.date_range('2024-01-01', periods=24, freq='H', tz='UTC')
+    df = pd.DataFrame({'Open': 1.0, 'High': 1.0, 'Low': 1.0, 'Close': 1.0}, index=idx)
+    result = features.engineer_m1_features(df)
+    categories = set(result['session'].unique())
+    expected = {'Asia', 'Asia/London', 'London', 'London/NY', 'NY', 'Other'}
+    assert expected.issubset(categories)
+    assert result['session'].dtype.name == 'category'
+
+
+def test_engineer_session_with_rangeindex():
+    df = pd.DataFrame({'Open': 1.0, 'High': 1.0, 'Low': 1.0, 'Close': 1.0}, index=range(5))
+    result = features.engineer_m1_features(df)
+    assert 'session' in result.columns
+    assert result['session'].dtype.name == 'category'


### PR DESCRIPTION
## Summary
- vectorize session column creation in `engineer_m1_features`
- bump version messages to v4.9.0
- add tests for `get_session_tag` and session distribution
- update CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dffe59c908325bdbb507622726c49