### PR TITLE
[Patch v5.0.1] Simplify pipeline fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2025-06-05
+- [Patch v5.0.1] Simplify FULL_PIPELINE fallback logic
+- New/Updated unit tests added for src.main
+- QA: pytest -q passed (13 tests)
 ### 2025-06-02
 - [Patch v4.8.12] Remove duplicate PREPARE_TRAIN_DATA and update font call
 - New/Updated unit tests added for src.main

--- a/tests/test_prepare_train_helpers.py
+++ b/tests/test_prepare_train_helpers.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+import os
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'src'))
+
+
+def test_prepare_train_data_calls_main(monkeypatch):
+    if 'src.main' in sys.modules:
+        del sys.modules['src.main']
+    main_module = importlib.import_module('src.main')
+
+    called = {}
+
+    def dummy_main(run_mode='FULL_PIPELINE', skip_prepare=False, suffix_from_prev_step=None):
+        called['run_mode'] = run_mode
+        return '_ok'
+
+    monkeypatch.setattr(main_module, 'main', dummy_main)
+    main_module.prepare_train_data()
+    assert called['run_mode'] == 'PREPARE_TRAIN_DATA'
+
+
+def test_train_models_calls_main(monkeypatch):
+    if 'src.main' in sys.modules:
+        del sys.modules['src.main']
+    main_module = importlib.import_module('src.main')
+
+    called = {}
+
+    def dummy_main(run_mode='FULL_PIPELINE', skip_prepare=False, suffix_from_prev_step=None):
+        called['run_mode'] = run_mode
+        return '_ok'
+
+    monkeypatch.setattr(main_module, 'main', dummy_main)
+    main_module.train_models()
+    assert called['run_mode'] == 'TRAIN_MODEL_ONLY'


### PR DESCRIPTION
## Summary
- simplify FULL_PIPELINE workflow to automatically generate missing data
- add helper wrappers `prepare_train_data` and `train_models`
- append changelog
- tests for new helper wrappers

## Testing
- `pytest -q`
- `pytest tests/test_prepare_train_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683e01672cf0832598be179da72f2699