### PR TITLE
Add 10 test blocks and remove skip warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,3 +153,7 @@
 - [Patch v5.0.9] เพิ่มชุดการทดสอบอีก 10 บล็อก และแก้ไขปัญหา skip
 - New/Updated unit tests added for src.features, src.data_loader
 - QA: pytest -q passed (93 tests)
+### 2025-06-09
+- [Patch v5.0.10] เพิ่มชุดการทดสอบอีก 10 บล็อกและแก้ไขการ skip
+- New/Updated unit tests added for src.data_loader, src.main
+- QA: pytest -q passed (103 tests)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -44,15 +44,13 @@ FUNCTIONS_INFO = [
 @pytest.mark.parametrize("path, func_name, expected_lineno", FUNCTIONS_INFO)
 def test_function_exists(path, func_name, expected_lineno):
     """Verify that each function exists near the expected line number."""
-    if not os.path.exists(path):
-        pytest.skip(f"{path} does not exist")
+    assert os.path.exists(path), f"{path} does not exist"
     with open(path, "r", encoding="utf-8") as f:
         tree = ast.parse(f.read())
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == func_name:
-            if abs(node.lineno - expected_lineno) > 5:
-                pytest.skip(
-                    f"Line mismatch for {func_name}: {node.lineno} (expected {expected_lineno})"
-                )
+            assert abs(node.lineno - expected_lineno) <= 5, (
+                f"Line mismatch for {func_name}: {node.lineno} (expected {expected_lineno})"
+            )
             return
-    pytest.skip(f"{func_name} not found in {path}")
+    assert False, f"{func_name} not found in {path}"

--- a/tests/test_loader_main_functions.py
+++ b/tests/test_loader_main_functions.py
@@ -1,0 +1,66 @@
+import os
+import pandas as pd
+import numpy as np
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import src.data_loader as dl
+import src.main as main
+
+
+def test_inspect_file_exists_true(tmp_path):
+    file_path = tmp_path / 'a.txt'
+    file_path.write_text('x', encoding='utf-8')
+    assert dl.inspect_file_exists(str(file_path)) is True
+
+
+def test_inspect_file_exists_false(tmp_path):
+    assert dl.inspect_file_exists(str(tmp_path / 'missing.txt')) is False
+
+
+def test_read_csv_with_date_parse_valid(tmp_path):
+    csv = tmp_path / 'f.csv'
+    df_in = pd.DataFrame({'A': [1, 2]})
+    df_in.to_csv(csv, index=False)
+    df_out = dl.read_csv_with_date_parse(str(csv))
+    pd.testing.assert_frame_equal(df_out, pd.read_csv(csv, parse_dates=True))
+
+
+def test_check_nan_percent_basic():
+    df = pd.DataFrame({'A': [1, np.nan]})
+    assert dl.check_nan_percent(df) == pytest.approx(0.5)
+
+
+def test_check_duplicates_subset():
+    df = pd.DataFrame({'A': [1, 1, 2], 'B': [1, 1, 3]})
+    assert dl.check_duplicates(df, subset=['A', 'B']) == 1
+
+
+def test_convert_thai_years_parses():
+    df = pd.DataFrame({'Date': ['2024-01-01']})
+    res = dl.convert_thai_years(df.copy(), 'Date')
+    assert pd.api.types.is_datetime64_ns_dtype(res['Date'])
+
+
+def test_prepare_datetime_index_sets_index():
+    df = pd.DataFrame({'Date': ['2024-01-01']})
+    res = dl.prepare_datetime_index(df.copy())
+    assert isinstance(res.index, pd.DatetimeIndex)
+
+
+def test_drop_nan_rows_drops_na():
+    df = pd.DataFrame({'A': [1, np.nan]})
+    res = main.drop_nan_rows(df)
+    assert len(res) == 1
+
+
+def test_convert_to_float32_dtype():
+    df = pd.DataFrame({'A': [1]})
+    res = main.convert_to_float32(df)
+    assert res['A'].dtype == 'float32'
+
+
+def test_write_test_file_creates(tmp_path):
+    path = dl.write_test_file(str(tmp_path / 'w.txt'))
+    assert os.path.exists(path)


### PR DESCRIPTION
## Summary
- expand test coverage with new loader & main helper tests
- assert function locations in registry tests instead of skipping
- document test additions in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e8fc09eb88325b95b8c40379769ff