### PR TITLE
Add 10 new test blocks and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,3 +162,8 @@
 - [Patch v5.0.11] เพิ่มชุดการทดสอบอีก 10 บล็อกและแก้ไข warning skip
 - New/Updated unit tests added for src.features, src.data_loader
 - QA: pytest -q passed (113 tests)
+
+### 2025-06-11
+- [Patch v5.0.12] เพิ่มชุดการทดสอบอีก 10 บล็อกและแก้ไข warning skip
+- New/Updated unit tests added for src.features, src.data_loader
+- QA: pytest -q passed (123 tests)

--- a/tests/test_additional_blocks.py
+++ b/tests/test_additional_blocks.py
@@ -72,3 +72,59 @@ def test_set_thai_font_no_error():
 def test_setup_fonts_creates_base(tmp_path):
     dl.setup_fonts(str(tmp_path))
     assert os.path.isdir(tmp_path)
+
+
+def test_ema_raises_type_error_non_series():
+    with pytest.raises(TypeError):
+        features.ema([1, 2, 3], 2)
+
+
+def test_sma_invalid_period_returns_nan_series():
+    series = pd.Series([1, 2, 3], dtype='float32')
+    result = features.sma(series, -1)
+    assert result.isna().all()
+
+
+def test_rolling_zscore_non_series_raises():
+    with pytest.raises(TypeError):
+        features.rolling_zscore([1, 2, 3], 3)
+
+
+
+def test_tag_price_structure_patterns_missing_columns():
+    df = pd.DataFrame({'Gain_Z': [0], 'High': [1], 'Low': [1], 'Close': [1]})
+    result = features.tag_price_structure_patterns(df)
+    assert (result['Pattern_Label'] == 'Normal').all()
+
+
+def test_calculate_m15_trend_zone_empty_df_returns_neutral():
+    df = pd.DataFrame()
+    result = features.calculate_m15_trend_zone(df)
+    assert (result['Trend_Zone'] == 'NEUTRAL').all()
+
+
+def test_get_session_tag_midnight():
+    ts = pd.Timestamp('2024-01-01 00:00', tz='UTC')
+    tag = features.get_session_tag(ts)
+    assert isinstance(tag, str)
+
+
+def test_simple_converter_none():
+    assert dl.simple_converter(None) is None
+
+
+def test_setup_output_directory_returns_absolute(tmp_path):
+    result = dl.setup_output_directory(str(tmp_path), 'out')
+    assert os.path.isabs(result)
+    assert os.path.isdir(result)
+
+
+def test_preview_datetime_format_missing_columns():
+    df = pd.DataFrame({'Date': ['2024-01-01']})
+    assert dl.preview_datetime_format(df) is None
+
+
+def test_safe_set_datetime_invalid_value_results_nat():
+    df = pd.DataFrame(index=[0])
+    dl.safe_set_datetime(df, 0, 'Date', 'invalid')
+    assert pd.isna(df.loc[0, 'Date'])


### PR DESCRIPTION
## Notes
- เพิ่มชุดการทดสอบใหม่อีก 10 ฟังก์ชันเพื่อป้องกัน warning/skip
- อัปเดต CHANGELOG ให้สอดคล้องกับ patch ล่าสุด

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e9547b5948325996b0a8e1d34cfce