### PR TITLE
Fix ProjectP import path

### DIFF
--- a/ProjectP.py
+++ b/ProjectP.py
@@ -1,12 +1,13 @@
 import sys
 import os
 
-# [Patch v5.0.14] Ensure proper import path for src package
+# [Patch] Set up import paths for local modules
 REPO_ROOT = os.path.dirname(__file__)
-if REPO_ROOT not in sys.path:
-    sys.path.insert(0, REPO_ROOT)
-from src.main import main
+for p in (REPO_ROOT, os.path.join(REPO_ROOT, 'src')):
+    if p not in sys.path:
+        sys.path.insert(0, p)
 
+from src.main import main
 
 def custom_helper_function():
     """Stubbed helper for tests."""


### PR DESCRIPTION
## Summary
- handle importing `src` modules when running ProjectP.py
- keep `custom_helper_function` near expected line

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ea3a241788325847c6c57d79339c3