### PR TITLE
Fix TRAIN_MODEL_ONLY NameError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,3 +194,8 @@
 - New/Updated unit tests added for src.features, src.data_loader
 - QA: pytest -q passed (155 tests)
 
+### 2025-06-15
+- [Patch v5.0.16] Import train_and_export_meta_model in main
+- New/Updated unit tests added for src.main
+- QA: pytest -q passed (156 tests)
+

--- a/src/main.py
+++ b/src/main.py
@@ -53,7 +53,7 @@ from features import (
     calculate_m1_entry_signals,
     load_features_for_model,
 )
-from src.strategy import run_all_folds_with_threshold
+from src.strategy import run_all_folds_with_threshold, train_and_export_meta_model
 import pandas as pd
 import numpy as np
 import shutil # For file moving in pipeline mode

--- a/tests/test_train_meta_model_import.py
+++ b/tests/test_train_meta_model_import.py
@@ -1,0 +1,14 @@
+import importlib
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+
+def test_train_and_export_meta_model_is_imported():
+    if 'src.main' in sys.modules:
+        del sys.modules['src.main']
+    main = importlib.import_module('src.main')
+    assert hasattr(main, 'train_and_export_meta_model')
+


### PR DESCRIPTION
## Summary
- import `train_and_export_meta_model` in `main`
- test that `train_and_export_meta_model` is available from `src.main`
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eb0acbb148325873597935f48feab