### PR TITLE
[Patch v5.0.16] Adjust soft cooldown trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,3 +194,8 @@
 - New/Updated unit tests added for src.features, src.data_loader
 - QA: pytest -q passed (155 tests)
 
+
+### 2025-06-15
+- [Patch v5.0.16] Fix soft cooldown trigger condition to require lookback trades
+- New/Updated unit tests added for tests.test_soft_cooldown_logic
+- QA: pytest -q passed (167 tests)

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -1960,7 +1960,7 @@ def run_backtest_simulation_v34(
                     if not relax_macd_cond:
                         if side == "BUY" and current_macd_smooth < 0: can_open_order = False; block_reason = f"NEG_MACD_BUY (MACD={current_macd_smooth:.3f})"
                         elif side == "SELL" and current_macd_smooth > 0: can_open_order = False; block_reason = f"POS_MACD_SELL (MACD={current_macd_smooth:.3f})"
-                if can_open_order and len(last_n_full_trade_pnls) >= SOFT_COOLDOWN_LOSS_COUNT:
+                if can_open_order and len(last_n_full_trade_pnls) >= SOFT_COOLDOWN_LOOKBACK:
                     recent_losses_count = sum(1 for pnl in last_n_full_trade_pnls[-SOFT_COOLDOWN_LOOKBACK:] if pnl < 0)
                     if recent_losses_count >= SOFT_COOLDOWN_LOSS_COUNT: can_open_order = False; block_reason = f"SOFT_COOLDOWN_{SOFT_COOLDOWN_LOSS_COUNT}L{SOFT_COOLDOWN_LOOKBACK}T ({recent_losses_count} losses)"
                 if block_reason: logging.debug(f"      Block Reason: {block_reason}")

--- a/tests/test_soft_cooldown_logic.py
+++ b/tests/test_soft_cooldown_logic.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+SOFT_COOLDOWN_LOOKBACK = 10
+SOFT_COOLDOWN_LOSS_COUNT = 3
+
+
+def check_can_open(pnls):
+    can_open = True
+    if can_open and len(pnls) >= SOFT_COOLDOWN_LOOKBACK:
+        recent_losses = sum(1 for p in pnls[-SOFT_COOLDOWN_LOOKBACK:] if p < 0)
+        if recent_losses >= SOFT_COOLDOWN_LOSS_COUNT:
+            can_open = False
+    return can_open
+
+
+def test_soft_cooldown_requires_lookback():
+    pnl_history = [-1] * SOFT_COOLDOWN_LOSS_COUNT
+    assert check_can_open(pnl_history)
+
+
+def test_soft_cooldown_triggers_after_lookback():
+    pnl_history = [-1] * SOFT_COOLDOWN_LOOKBACK
+    assert not check_can_open(pnl_history)


### PR DESCRIPTION
## Summary
- fix soft cooldown to check lookback length before blocking
- add unit tests for soft cooldown logic
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eb38a5e188325a288a73f852d9e74