### PR TITLE
Add Optuna CatBoost sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,11 @@
 - QA: pytest -q passed (167 tests)
 
 ### 2025-06-16
+- [Patch v5.0.18] Optuna CatBoost sweep function
+- New/Updated unit tests added for tests.test_hyperparameter_sweep, tests.test_function_registry
+- QA: pytest -q passed (168 tests)
+
+### 2025-06-16
 - [Patch v5.0.17] Add soft cooldown helper and update tests
 - New/Updated unit tests added for src.cooldown_utils, tests.test_soft_cooldown_logic
 - QA: pytest -q passed (167 tests)

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -36,7 +36,7 @@ except ImportError:
     from data_loader import safe_get_global  # fallback to direct import if package context missing
 import traceback
 from joblib import dump as joblib_dump # Use joblib dump directly
-from sklearn.model_selection import train_test_split, TimeSeriesSplit # Ensure TimeSeriesSplit is imported
+from sklearn.model_selection import train_test_split, TimeSeriesSplit, cross_val_score
 import gc # For memory management
 # Import ML libraries conditionally (assuming they are checked/installed in Part 1)
 try:
@@ -3651,6 +3651,40 @@ def run_hyperparameter_sweep(
         model_paths, feats = train_func(**sweep_params)
         results.append({"params": sweep_params, "model_paths": model_paths, "features": feats})
     return results
+
+
+# [Patch v5.0.18] Add Optuna-based CatBoost sweep
+def run_optuna_catboost_sweep(
+    X: pd.DataFrame,
+    y: pd.Series,
+    n_trials: int = 50,
+    n_splits: int = 5,
+):
+    """Runs Optuna hyperparameter search for CatBoost."""
+    if optuna is None or CatBoostClassifier is None:
+        logging.error("(Error) optuna or catboost not available for sweep")
+        return None, {}
+
+    def objective(trial):
+        params = {
+            "iterations": trial.suggest_int("iterations", 50, 200),
+            "depth": trial.suggest_int("depth", 4, 10),
+            "learning_rate": trial.suggest_float("learning_rate", 1e-3, 1e-1, log=True),
+            "l2_leaf_reg": trial.suggest_float("l2_leaf_reg", 1e-2, 10, log=True),
+            "border_count": trial.suggest_int("border_count", 32, 64),
+            "random_strength": trial.suggest_float("random_strength", 0, 1),
+            "eval_metric": "AUC",
+            "verbose": False,
+            "task_type": "CPU",
+        }
+        model = CatBoostClassifier(**params)
+        cv = TimeSeriesSplit(n_splits=n_splits)
+        scores = cross_val_score(model, X, y, cv=cv, scoring="roc_auc")
+        return float(np.mean(scores))
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=n_trials)
+    return study.best_value, study.best_params
 
 
 def generate_open_signals(df: pd.DataFrame) -> np.ndarray:

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -32,12 +32,12 @@ FUNCTIONS_INFO = [
     ("src/main.py", "run_initial_backtest", 1701),
     ("src/main.py", "save_final_data", 1706),
     ("src/strategy.py", "run_backtest_simulation_v34", 1632),
-    ("src/strategy.py", "initialize_time_series_split", 3678),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3683),
-    ("src/strategy.py", "apply_kill_switch", 3688),
-    ("src/strategy.py", "log_trade", 3693),
+    ("src/strategy.py", "initialize_time_series_split", 3712),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3717),
+    ("src/strategy.py", "apply_kill_switch", 3722),
+    ("src/strategy.py", "log_trade", 3727),
     ("src/strategy.py", "calculate_metrics", 2604),
-    ("src/strategy.py", "aggregate_fold_results", 3698),
+    ("src/strategy.py", "aggregate_fold_results", 3732),
     ("ProjectP.py", "custom_helper_function", 7),
 ]
 

--- a/tests/test_hyperparameter_sweep.py
+++ b/tests/test_hyperparameter_sweep.py
@@ -5,7 +5,8 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, ROOT_DIR)
 sys.path.insert(0, os.path.join(ROOT_DIR, 'src'))
 
-from src.strategy import run_hyperparameter_sweep
+import pandas as pd
+from src.strategy import run_hyperparameter_sweep, run_optuna_catboost_sweep
 
 def test_run_hyperparameter_sweep_basic(tmp_path):
     calls = []
@@ -20,3 +21,11 @@ def test_run_hyperparameter_sweep_basic(tmp_path):
     assert len(calls) == 4
     for res in results:
         assert "model_paths" in res and "features" in res
+
+
+def test_run_optuna_catboost_sweep_smoke():
+    X = pd.DataFrame({"a": range(10), "b": range(10)})
+    y = pd.Series([0, 1] * 5)
+    best_val, best_params = run_optuna_catboost_sweep(X, y, n_trials=1, n_splits=2)
+    assert isinstance(best_val, float)
+    assert isinstance(best_params, dict)


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `run_optuna_catboost_sweep` สำหรับหาค่า hyperparameter ด้วย Optuna
- ปรับเลขบรรทัดคาดหวังใน `test_function_registry`
- ขยายการทดสอบใน `test_hyperparameter_sweep`
- อัปเดต `CHANGELOG`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ebe072d5c8325b0e88172d9d558b2