### PR TITLE
[Patch v5.1.0] ปรับข้อความฝึกใน hyperparameter sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,3 +235,7 @@
 - New/Updated unit tests added for tests.test_soft_cooldown_logic
 - QA: pytest -q passed (169 tests)
 
+### 2025-06-20
+- [Patch v5.1.0] ปรับข้อความ dummy_train_func เป็นภาษาไทย
+- QA: pytest -q passed (170 tests)
+

--- a/hyperparameter_sweep.py
+++ b/hyperparameter_sweep.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-[Patch v5.0.19] Simple hyperparameter sweep runner
+[Patch v5.1.0] Simple hyperparameter sweep runner
 สร้างสคริปต์ตัวอย่างสำหรับรันทดสอบ hyperparameter sweep
 """
 
@@ -25,8 +25,8 @@ def main() -> None:
     }
 
     def dummy_train_func(**kwargs):
-        # [Patch v5.0.19] ใช้ฟังก์ชันฝึกแบบจำลองจำลองเพื่อให้รันเร็ว
-        print(f"\u0e40\u0e23\u0e34\u0e48\u0e21\u0e1e\u0e32\u0e23\u0e32\u0e21\u0e34\u0e40\u0e15\u0e2d\u0e23\u0e4c: {kwargs}")
+        # [Patch v5.1.0] ใช้ฟังก์ชันฝึกแบบจำลองจำลองเพื่อให้รันเร็ว
+        print(f"เริ่มฝึก dummy_train_func ด้วยพารามิเตอร์: {kwargs}")
         return {"model": "path"}, ["feature1", "feature2"]
 
     results = run_hyperparameter_sweep(base_params, grid, train_func=dummy_train_func)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -34,12 +34,12 @@ FUNCTIONS_INFO = [
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1634),
 
-    ("src/strategy.py", "initialize_time_series_split", 3729),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3734),
-    ("src/strategy.py", "apply_kill_switch", 3739),
-    ("src/strategy.py", "log_trade", 3744),
+    ("src/strategy.py", "initialize_time_series_split", 3741),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3746),
+    ("src/strategy.py", "apply_kill_switch", 3751),
+    ("src/strategy.py", "log_trade", 3756),
     ("src/strategy.py", "calculate_metrics", 2621),
-    ("src/strategy.py", "aggregate_fold_results", 3749),
+    ("src/strategy.py", "aggregate_fold_results", 3761),
 
     ("ProjectP.py", "custom_helper_function", 7),
 ]


### PR DESCRIPTION
## Summary
- ปรับ print ใน `dummy_train_func` ให้เป็นภาษาไทยและบันทึกแพทช์เวอร์ชัน
- ปรับบรรทัดตรวจสอบใน `test_function_registry` ให้ตรงกับไฟล์ strategy
- เพิ่มบันทึกใน CHANGELOG สำหรับแพทช์นี้

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ec98d948083258f2c39f96949a0e3