### PR TITLE
Centralize logger and add error handling

### DIFF
--- a/ProjectP.py
+++ b/ProjectP.py
@@ -1,5 +1,7 @@
 """Bootstrap script for running the main entry point."""
 
+from src.config import logger
+import sys
 from src.main import main
 
 def custom_helper_function():
@@ -11,3 +13,6 @@ if __name__ == '__main__':
         main()
     except KeyboardInterrupt:
         print("\n(Stopped) การทำงานถูกยกเลิกโดยผู้ใช้.")
+    except Exception as e:
+        logger.error("เกิดข้อผิดพลาดที่ไม่คาดคิด: %s", str(e), exc_info=True)
+        sys.exit(1)

--- a/hyperparameter_sweep.py
+++ b/hyperparameter_sweep.py
@@ -6,6 +6,8 @@
 
 """Example script for running hyperparameter sweeps."""
 
+from src.config import logger
+import sys
 from src.strategy import run_hyperparameter_sweep
 
 
@@ -30,4 +32,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        logger.error("เกิดข้อผิดพลาดที่ไม่คาดคิด: %s", str(e), exc_info=True)
+        sys.exit(1)

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,10 @@
 # <<< MODIFIED v4.8.1: Refined auto-train logic (log loading, context cols), confirmed dtype passing, verified model loading checks, added more robust function call checks >>>
 # <<< MODIFIED v4.8.2: Corrected SyntaxError in __main__ block (added except/finally for the main try block), updated log messages and versioning, robust global access in finally >>>
 # <<< MODIFIED v4.8.3: Applied SyntaxError fix for try-except global variable checks to all relevant globals in this part. >>>
+try:
+    from src.config import logger
+except Exception:  # pragma: no cover - fallback for tests
+    import logging as logger
 import logging
 import os
 import sys
@@ -1343,14 +1347,14 @@ def main(run_mode='FULL_PIPELINE', skip_prepare=False, suffix_from_prev_step=Non
 # ==============================================================================
 if __name__ == "__main__":
     start_time_script = time.time()
-    logging.info(f"(Starting) Script Gold Trading AI v4.8.4...") # Updated version
+    logger.info(f"(Starting) Script Gold Trading AI v4.8.4...")
 
     selected_run_mode = 'FULL_PIPELINE'
     # selected_run_mode = 'PREPARE_TRAIN_DATA'
     # selected_run_mode = 'TRAIN_MODEL_ONLY'
     # selected_run_mode = 'FULL_RUN'
 
-    logging.info(f"(Starting) กำลังเริ่มการทำงานหลัก (main) ในโหมด: {selected_run_mode}...")
+    logger.info(f"(Starting) กำลังเริ่มการทำงานหลัก (main) ในโหมด: {selected_run_mode}...")
     final_run_suffix = None
     # <<< MODIFIED v4.8.2: Ensured this try...except...finally block is correctly structured >>>
     try:
@@ -1395,19 +1399,22 @@ if __name__ == "__main__":
         else:
             logging.info(f"\n(Skipping Log Analysis) Run mode '{selected_run_mode}' does not require log analysis.")
 
-    except SystemExit as se_main: # Renamed to avoid conflict
-        logging.critical(f"\n(Critical Error) สคริปต์ออกก่อนเวลา: {se_main}")
-        # Optionally re-raise or handle further if needed: raise se_main
+    except SystemExit as se_main:
+        logger.critical(f"\n(Critical Error) สคริปต์ออกก่อนเวลา: {se_main}")
     except KeyboardInterrupt:
-        logging.warning("\n(Stopped) การทำงานหยุดโดยผู้ใช้ (KeyboardInterrupt).")
-    except NameError as ne_main: # Renamed
-        logging.critical(f"\n(Error) NameError in __main__: '{ne_main}'. Critical function or variable likely missing.", exc_info=True)
-    except Exception as e_main_general: # Renamed
-        logging.critical("\n(Error) เกิดข้อผิดพลาดที่ไม่คาดคิดใน __main__:", exc_info=True)
+        logger.warning("\n(Stopped) การทำงานหยุดโดยผู้ใช้ (KeyboardInterrupt).")
+    except NameError as ne_main:
+        logger.critical(
+            f"\n(Error) NameError in __main__: '{ne_main}'. Critical function or variable likely missing.",
+            exc_info=True,
+        )
+    except Exception as e_main_general:
+        logger.error("เกิดข้อผิดพลาดที่ไม่คาดคิด: %s", str(e_main_general), exc_info=True)
+        sys.exit(1)
     finally:
         end_time_script = time.time()
         total_duration = end_time_script - start_time_script
-        logging.info(f"\n(Finished) Script Gold Trading AI v4.8.4 เสร็จสมบูรณ์!") # Updated version
+        logger.info(f"\n(Finished) Script Gold Trading AI v4.8.4 เสร็จสมบูรณ์!")
         
         final_tuning_mode_log = "Unknown"
         # Check globals first, then locals if not found in globals (though it should be global)
@@ -1415,7 +1422,7 @@ if __name__ == "__main__":
             final_tuning_mode_log = globals()['tuning_mode_used']
         elif 'tuning_mode_used' in locals() and locals()['tuning_mode_used'] is not None: # Check local scope as fallback
             final_tuning_mode_log = locals()['tuning_mode_used']
-        logging.info(f"   Tuning Mode ที่ใช้: {final_tuning_mode_log}")
+        logger.info(f"   Tuning Mode ที่ใช้: {final_tuning_mode_log}")
 
         output_dir_final_path = None
         try:
@@ -1431,17 +1438,17 @@ if __name__ == "__main__":
                 output_dir_final_path = output_dir_val
 
             if output_dir_final_path and os.path.exists(output_dir_final_path):
-                logging.info(f"   ผลลัพธ์ถูกบันทึกไปที่: {output_dir_final_path}")
-                logging.info(f"   ไฟล์ Log หลัก: {log_filename_val}") # Directly use LOG_FILENAME
+                logger.info(f"   ผลลัพธ์ถูกบันทึกไปที่: {output_dir_final_path}")
+                logger.info(f"   ไฟล์ Log หลัก: {log_filename_val}")
             elif output_dir_final_path:
-                logging.warning(f"   (Warning) ไม่พบ Output Directory ที่คาดหวัง: {output_dir_final_path}")
+                logger.warning(f"   (Warning) ไม่พบ Output Directory ที่คาดหวัง: {output_dir_final_path}")
             else:
-                logging.warning("   (Warning) ไม่สามารถกำหนด Output Directory path.")
+                logger.warning("   (Warning) ไม่สามารถกำหนด Output Directory path.")
         except Exception as e_report_path:
-            logging.warning(f"   (Warning) Error reporting output path: {e_report_path}")
+            logger.warning(f"   (Warning) Error reporting output path: {e_report_path}")
 
-        logging.info(f"   เวลาดำเนินการทั้งหมด: {total_duration:.2f} วินาที ({total_duration/60:.2f} นาที).")
-        logging.info("--- End of Script ---")
+        logger.info(f"   เวลาดำเนินการทั้งหมด: {total_duration:.2f} วินาที ({total_duration/60:.2f} นาที).")
+        logger.info("--- End of Script ---")
 
 # === END OF PART 10/12 ===
 # === START OF PART 11/12 ===
@@ -1456,7 +1463,7 @@ import time
 # import MetaTrader5 as mt5 # Import commented out as it's a placeholder
 # import pandas as pd # Import commented out as it's not used in placeholder
 
-logging.info("Loading Part 11: MT5 Connector (Placeholder)...")
+logger.info("Loading Part 11: MT5 Connector (Placeholder)...")
 
 # --- MT5 Connection Parameters (Placeholder Examples) ---
 # These would typically be loaded from a secure config file or environment variables

--- a/src/utils/sessions.py
+++ b/src/utils/sessions.py
@@ -1,6 +1,9 @@
 """Session tagging utilities shared across modules."""
 
-import logging
+try:
+    from src.config import logger
+except Exception:  # pragma: no cover - fallback when config import fails
+    import logging as logger
 import pandas as pd
 
 
@@ -20,7 +23,7 @@ def get_session_tag(timestamp, session_times_utc=None):
         try:
             session_times_utc_local = SESSION_TIMES_UTC
         except NameError:
-            logging.warning(
+            logger.warning(
                 "get_session_tag: Global SESSION_TIMES_UTC not found, using default.")
             session_times_utc_local = {"Asia": (0, 8), "London": (7, 16), "NY": (13, 21)}
     else:
@@ -43,5 +46,5 @@ def get_session_tag(timestamp, session_times_utc=None):
                     sessions.append(name)
         return "/".join(sorted(sessions)) if sessions else "Other"
     except Exception as e:  # pragma: no cover - unexpected failures
-        logging.error(f"   (Error) Error in get_session_tag for {timestamp}: {e}", exc_info=True)
+        logger.error(f"   (Error) Error in get_session_tag for {timestamp}: {e}", exc_info=True)
         return "Error_Tagging"

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -3,11 +3,11 @@ import os
 import pytest
 
 FUNCTIONS_INFO = [
-    ("src/config.py", "log_library_version", 70),
-    ("src/config.py", "_ensure_ta_installed", 114),
-    ("src/config.py", "is_colab", 305),
-    ("src/config.py", "print_gpu_utilization", 377),
-    ("src/config.py", "show_system_status", 421),
+    ("src/config.py", "log_library_version", 84),
+    ("src/config.py", "_ensure_ta_installed", 128),
+    ("src/config.py", "is_colab", 319),
+    ("src/config.py", "print_gpu_utilization", 391),
+    ("src/config.py", "show_system_status", 435),
     ("src/data_loader.py", "inspect_file_exists", 846),
     ("src/data_loader.py", "read_csv_with_date_parse", 851),
     ("src/data_loader.py", "check_nan_percent", 858),


### PR DESCRIPTION
## Summary
- set up a shared `logger` in `src.config`
- import `logger` with fallbacks in `src.main` and `src.utils.sessions`
- add error handling in main entry points
- update function-line expectations in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ed80ba4548325a1f8939fcf9803dc