### PR TITLE
Fix pandas FutureWarning in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def simple_m1_df():
         'Low': [9.8, 9.9, 10.0, 10.1, 10.2],
         'Close': [10.1, 10.2, 10.3, 10.4, 10.5],
         'Volume': [100, 110, 120, 130, 140],
-        'Datetime': pd.date_range('2023-01-01', periods=5, freq='T')
+        'Datetime': pd.date_range('2023-01-01', periods=5, freq='min')
     }
     df = pd.DataFrame(data)
     df.set_index('Datetime', inplace=True)

--- a/tests/test_strategy_meta_model.py
+++ b/tests/test_strategy_meta_model.py
@@ -21,7 +21,7 @@ class DummyPool:
 
 def test_train_and_export_meta_model(tmp_path, monkeypatch):
     trade_log = pd.DataFrame({
-        'entry_time': pd.date_range('2023-01-01', periods=5, freq='T'),
+        'entry_time': pd.date_range('2023-01-01', periods=5, freq='min'),
         'exit_reason': ['TP', 'SL', 'TP', 'SL', 'TP']
     })
     m1 = pd.DataFrame({
@@ -30,7 +30,7 @@ def test_train_and_export_meta_model(tmp_path, monkeypatch):
         'Low': np.linspace(1, 5, 5)-0.1,
         'Close': np.linspace(1, 5, 5),
         'ATR_14': np.ones(5)
-    }, index=pd.date_range('2023-01-01', periods=5, freq='T'))
+    }, index=pd.date_range('2023-01-01', periods=5, freq='min'))
     m1_path = tmp_path / 'm1.csv'
     m1.to_csv(m1_path)
     monkeypatch.setattr(strategy, 'USE_GPU_ACCELERATION', False, raising=False)


### PR DESCRIPTION
## Summary
- use `'min'` frequency instead of `'T'` in test fixtures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683edddb7ff08325810bba68eb95703a