### PR TITLE
Fix profile warnings and pytest config

### DIFF
--- a/profile_backtest.py
+++ b/profile_backtest.py
@@ -28,7 +28,14 @@ def main_profile(csv_path: str, num_rows: int = 5000) -> None:
             # Fallback for files where the first column becomes the index
             if not isinstance(df.index, pd.DatetimeIndex):
                 df.index = pd.to_datetime(df.index, errors='coerce')
-    run_backtest_simulation_v34(df, label="profile", initial_capital_segment=10000)
+    # Provide minimal fold_config and current_fold_index to avoid warnings
+    run_backtest_simulation_v34(
+        df,
+        label="profile",
+        initial_capital_segment=10000,
+        fold_config={},
+        current_fold_index=0,
+    )
 
 
 def profile_from_cli() -> None:


### PR DESCRIPTION
## Summary
- avoid fold_config warnings in profiling script
- simplify test handling when src.config not provided

## Testing
- `pytest -q`
- `PYTHONPATH=./src python profile_backtest.py XAUUSD_M1.csv --rows 500 2>&1 | grep -E "fold_config|current_fold_index" | head`

------
https://chatgpt.com/codex/tasks/task_e_683edccb502c83259fb0cea2475edd6b