### PR TITLE
[Patch v5.1.0] ปรับคอมเมนต์ dummy_train_func

### DIFF
--- a/hyperparameter_sweep.py
+++ b/hyperparameter_sweep.py
@@ -21,7 +21,7 @@ def main() -> None:
     }
 
     def dummy_train_func(**kwargs):
-        # [Patch v5.1.0] ใช้ฟังก์ชันฝึกแบบจำลองจำลองเพื่อให้รันเร็ว
+        # [Patch v5.1.0] ปรับข้อความพิมพ์ให้เป็นภาษาไทย พร้อมระบุพารามิเตอร์ชัดเจน
         print(f"เริ่มฝึก dummy_train_func ด้วยพารามิเตอร์: {kwargs}")
         return {"model": "path"}, ["feature1", "feature2"]
 


### PR DESCRIPTION
## Summary
- ปรับคอมเมนต์ใน `dummy_train_func` เพื่อระบุจุดประสงค์ว่าพิมพ์ข้อความเป็นภาษาไทย

## Testing
- `pytest -q` *(ล้มเหลว 1 รายการ)*

------
https://chatgpt.com/codex/tasks/task_e_683ee19e9d388325bb25aa2116fd3f0a