### PR TITLE
[Patch v5.1.0] ตรวจสอบคอลัมน์ก่อนรัน backtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,3 +273,8 @@
 - New/Updated unit tests added for src.strategy
 - QA: pytest -q passed (183 tests)
 
+### 2025-06-27
+- [Patch v5.1.0] ตรวจสอบคอลัมน์ที่จำเป็นก่อนรัน backtest
+- New/Updated unit tests added for profile_backtest และ src.strategy
+- QA: pytest -q passed (185 tests)
+

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -1639,6 +1639,14 @@ def run_backtest_simulation_v34(
     Runs the core backtesting simulation loop for a single fold, side, and fund profile.
     (v4.8.8 Patch 26.5.1: Unified error handling, logging, and exit logic fixes)
     """
+    # [Patch v5.1.0] ตรวจสอบคอลัมน์สำคัญก่อนดำเนินการ backtest
+    required_cols = ["Open", "High", "Low", "Close"]
+    missing = [c for c in required_cols if c not in df_m1_segment_pd.columns]
+    if missing:
+        # เมื่อเรียกโดย profile_backtest จะตรวจสอบและ return ก่อนถึงจุดนี้
+        raise ValueError(
+            f"Missing required columns in input DataFrame for backtest: {missing}"
+        )
     global meta_model_type_used, meta_meta_model_type_used, USE_REENTRY, REENTRY_COOLDOWN_BARS, TIMEFRAME_MINUTES_M1, POINT_VALUE, MAX_CONCURRENT_ORDERS, MAX_HOLDING_BARS, COMMISSION_PER_001_LOT, SPREAD_POINTS, MIN_SLIPPAGE_POINTS, MAX_SLIPPAGE_POINTS, MAX_DRAWDOWN_THRESHOLD, ENABLE_FORCED_ENTRY, FORCED_ENTRY_BAR_THRESHOLD, FORCED_ENTRY_MIN_SIGNAL_SCORE, FORCED_ENTRY_LOOKBACK_PERIOD, FORCED_ENTRY_CHECK_MARKET_COND, FORCED_ENTRY_MAX_ATR_MULT, FORCED_ENTRY_MIN_GAIN_Z_ABS, FORCED_ENTRY_ALLOWED_REGIMES, FE_ML_FILTER_THRESHOLD, forced_entry_max_consecutive_losses, OUTPUT_DIR, USE_META_CLASSIFIER, BASE_BE_SL_R_THRESHOLD, DYNAMIC_BE_ATR_THRESHOLD_HIGH, DYNAMIC_BE_R_ADJUST_HIGH, META_MIN_PROBA_THRESH, REENTRY_MIN_PROBA_THRESH
 
     meta_proba_tp_for_log = np.nan; meta2_proba_tp_for_log = np.nan; meta_proba_tp_for_fe_log = np.nan; total_ib_lot_accumulator = 0.0

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -32,15 +32,15 @@ FUNCTIONS_INFO = [
     ("src/main.py", "run_initial_backtest", 1701),
     ("src/main.py", "save_final_data", 1706),
 
-    ("src/strategy.py", "run_backtest_simulation_v34", 1611),
+    ("src/strategy.py", "run_backtest_simulation_v34", 1615),
 
 
-    ("src/strategy.py", "initialize_time_series_split", 3716),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3721),
-    ("src/strategy.py", "apply_kill_switch", 3726),
-    ("src/strategy.py", "log_trade", 3731),
-    ("src/strategy.py", "calculate_metrics", 2598),
-    ("src/strategy.py", "aggregate_fold_results", 3736),
+    ("src/strategy.py", "initialize_time_series_split", 3729),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3734),
+    ("src/strategy.py", "apply_kill_switch", 3739),
+    ("src/strategy.py", "log_trade", 3744),
+    ("src/strategy.py", "calculate_metrics", 2610),
+    ("src/strategy.py", "aggregate_fold_results", 3749),
 
 
     ("ProjectP.py", "custom_helper_function", 7),

--- a/tests/test_profile_backtest.py
+++ b/tests/test_profile_backtest.py
@@ -7,6 +7,7 @@ sys.path.insert(0, ROOT_DIR)
 sys.path.insert(0, os.path.join(ROOT_DIR, 'src'))
 
 import profile_backtest
+import logging
 
 
 def test_main_profile_runs(tmp_path):
@@ -20,3 +21,16 @@ def test_main_profile_runs(tmp_path):
     csv_path = tmp_path / 'mini.csv'
     df.to_csv(csv_path, index=False)
     profile_backtest.main_profile(str(csv_path), num_rows=2)
+
+
+def test_main_profile_missing_columns(tmp_path, caplog):
+    df = pd.DataFrame({
+        'Datetime': pd.date_range('2022-01-01', periods=3, freq='min', tz='UTC'),
+        'Open': [1, 2, 3],
+        'Close': [1, 2, 3]
+    })
+    csv_path = tmp_path / 'missing.csv'
+    df.to_csv(csv_path, index=False)
+    caplog.set_level(logging.ERROR)
+    profile_backtest.main_profile(str(csv_path), num_rows=2)
+    assert "Missing required columns" in caplog.text

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from src import strategy
+import pytest
 
 
 def test_run_backtest_simulation_missing_cols(simple_m1_df):
@@ -24,3 +25,17 @@ def test_run_backtest_simulation_missing_cols(simple_m1_df):
     )
     run_summary = result[5]
     assert run_summary['error_in_loop']
+
+
+def test_run_backtest_simulation_missing_price_cols(simple_m1_df):
+    df = simple_m1_df.drop(columns=['High'])
+    df['ATR_14_Shifted'] = 1.0
+    df['ATR_14'] = 1.0
+    with pytest.raises(ValueError):
+        strategy.run_backtest_simulation_v34(
+            df,
+            label='TEST',
+            initial_capital_segment=1000,
+            fold_config={},
+            current_fold_index=0,
+        )


### PR DESCRIPTION
## Notes
- เพิ่มฟังก์ชันตรวจสอบคอลัมน์ที่จำเป็นใน `main_profile`
- `run_backtest_simulation_v34` จะ raise `ValueError` หาก DataFrame ขาดคอลัมน์ราคา
- ปรับเลขบรรทัดใน `test_function_registry`
- เพิ่ม unit tests สำหรับกรณีคอลัมน์หายไป

## Summary
- `main_profile` ตรวจสอบคอลัมน์ `Open/High/Low/Close` และ log error ก่อนรัน backtest【F:profile_backtest.py†L34-L41】
- `run_backtest_simulation_v34` ตรวจสอบคอลัมน์สำคัญทันทีที่เริ่มฟังก์ชันและ raise error เมื่อจำเป็น【F:src/strategy.py†L1642-L1649】
- เพิ่มชุดทดสอบใหม่รองรับพฤติกรรมดังกล่าว【F:tests/test_profile_backtest.py†L26-L36】【F:tests/test_simulation.py†L30-L41】
- ปรับบรรทัดที่คาดหวังใน `test_function_registry.py` ให้ตรงกับไฟล์จริง【F:tests/test_function_registry.py†L35-L43】

## Testing
- `pytest -q`【ee2b44†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_683ee349995483259fa309bfccc00c67