### PR TITLE
[Patch v5.1.0] รวมลำดับการแสดงผล run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,3 +273,7 @@
 - New/Updated unit tests added for src.strategy
 - QA: pytest -q passed (183 tests)
 
+### 2025-06-27
+- [Patch v5.1.0] รวมลำดับการแสดงผล Run ให้อยู่ใน loop เดียวกัน
+- QA: pytest -q passed (183 tests)
+

--- a/hyperparameter_sweep.py
+++ b/hyperparameter_sweep.py
@@ -25,9 +25,11 @@ def main() -> None:
         print(f"เริ่มฝึก dummy_train_func ด้วยพารามิเตอร์: {kwargs}")
         return {"model": "path"}, ["feature1", "feature2"]
 
-    results = run_hyperparameter_sweep(base_params, grid, train_func=dummy_train_func)
-
-    for idx, res in enumerate(results, start=1):
+    # \[Patch v5.1.0] รวมลำดับการแสดงผล Run ให้อยู่ใน loop เดียวกัน
+    for idx, res in enumerate(
+        run_hyperparameter_sweep(base_params, grid, train_func=dummy_train_func),
+        start=1,
+    ):
         print(f"Run {idx}: {res}")
 
 


### PR DESCRIPTION
## Summary
- รวมลำดับการแสดงผล Run ให้อยู่ใน loop เดียวกันใน `hyperparameter_sweep.py`
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ee53a5aac832592633ef5287b9701