### PR TITLE
[Patch v1.1.0] เปลี่ยน sweep runner ใช้งาน real training

### DIFF
--- a/hyperparameter_sweep.py
+++ b/hyperparameter_sweep.py
@@ -1,39 +1,56 @@
 # -*- coding: utf-8 -*-
 """
-[Patch v5.1.0] Simple hyperparameter sweep runner
-สร้างสคริปต์ตัวอย่างสำหรับรันทดสอบ hyperparameter sweep
+[Patch v1.1.0] Hyperparameter sweep using real training
+สคริปต์สำหรับรัน hyperparameter sweep และบันทึกผลลัพธ์
 """
 
-"""Example script for running hyperparameter sweeps."""
+import os
+import sys
+import argparse
+from itertools import product
+import pandas as pd
 
 from src.config import logger
-import sys
-from src.strategy import run_hyperparameter_sweep
+from src.training import real_train_func
+
+
+def run_sweep(output_dir: str) -> None:
+    """Run hyperparameter combinations and save summary."""
+    learning_rates = [0.01, 0.05]
+    depths = [6, 8]
+    os.makedirs(output_dir, exist_ok=True)
+    summary_rows = []
+    for run_id, (lr, depth) in enumerate(product(learning_rates, depths), start=1):
+        print(f"เริ่มพารามิเตอร์ run {run_id}: {{'learning_rate': lr, 'depth': depth}}")
+        result = real_train_func(output_dir=output_dir, learning_rate=lr, depth=depth)
+        print(
+            f"Run {run_id}: params={{'learning_rate': lr, 'depth': depth}}, model_path={result['model_path']}, metrics={result.get('metrics')}"
+        )
+        summary_rows.append(
+            {
+                'run_id': run_id,
+                'learning_rate': lr,
+                'depth': depth,
+                'model_path': result['model_path'].get('model', ''),
+                'features': ','.join(result.get('features', [])),
+                **result.get('metrics', {}),
+            }
+        )
+
+    df = pd.DataFrame(summary_rows)
+    summary_path = os.path.join(output_dir, 'summary.csv')
+    df.to_csv(summary_path, index=False)
+    print(f"Hyperparameter sweep summary saved to {summary_path}")
 
 
 def main() -> None:
-    """ตัวอย่างการรัน hyperparameter sweep แบบย่อ"""
-
-    base_params = {"output_dir": "sweep_results"}
-    grid = {
-        "learning_rate": [0.01, 0.05],
-        "depth": [6, 8],
-    }
-
-    def dummy_train_func(**kwargs):
-        # [Patch v5.1.0] แสดงข้อความพร้อมลำดับ run จาก strategy.py
-        print(f"เริ่มฝึก dummy_train_func ด้วยพารามิเตอร์: {kwargs}")
-        return {"model": "path"}, ["feature1", "feature2"]
-
-    # \[Patch v5.1.0] รวมลำดับการแสดงผล Run ให้อยู่ใน loop เดียวกัน
-    for idx, res in enumerate(
-        run_hyperparameter_sweep(base_params, grid, train_func=dummy_train_func),
-        start=1,
-    ):
-        print(f"Run {idx}: {res}")
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', default='sweep_results')
+    args = parser.parse_args()
+    run_sweep(args.output_dir)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     try:
         main()
     except Exception as e:

--- a/src/training.py
+++ b/src/training.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""[Patch v1.1.0] Training utilities for hyperparameter sweep."""
+import os
+import numpy as np
+import pandas as pd
+from joblib import dump
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score, roc_auc_score
+from sklearn.linear_model import LogisticRegression
+
+try:
+    from catboost import CatBoostClassifier
+except Exception:  # pragma: no cover - fallback if catboost missing
+    CatBoostClassifier = None
+
+
+# [Patch v1.1.0] Real training function using CatBoost (or logistic regression fallback)
+def real_train_func(output_dir: str, learning_rate: float = 0.01, depth: int = 6) -> dict:
+    """Train a simple model and return model path, used features and metrics."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    X, y = make_classification(n_samples=200, n_features=5, n_informative=3, random_state=42)
+    feature_names = [f"f{i}" for i in range(X.shape[1])]
+    df_X = pd.DataFrame(X, columns=feature_names)
+    X_train, X_test, y_train, y_test = train_test_split(df_X, y, test_size=0.25, random_state=42)
+
+    if CatBoostClassifier:
+        model = CatBoostClassifier(iterations=100, learning_rate=learning_rate, depth=depth, verbose=False)
+        model.fit(X_train, y_train)
+        y_prob = model.predict_proba(X_test)[:, 1]
+        y_pred = (y_prob > 0.5).astype(int)
+    else:
+        model = LogisticRegression(max_iter=1000)
+        model.fit(X_train, y_train)
+        y_prob = model.predict_proba(X_test)[:, 1]
+        y_pred = model.predict(X_test)
+
+    acc = accuracy_score(y_test, y_pred)
+    auc = roc_auc_score(y_test, y_prob)
+
+    model_filename = f"model_lr{learning_rate}_depth{depth}.joblib"
+    model_path = os.path.join(output_dir, model_filename)
+    dump(model, model_path)
+
+    return {
+        "model_path": {"model": model_path},
+        "features": feature_names,
+        "metrics": {"accuracy": acc, "auc": auc},
+    }


### PR DESCRIPTION
## Summary
- เพิ่ม `real_train_func` สำหรับฝึก CatBoost หรือ LogisticRegression แบบย่อ
- เขียนสคริปต์ `hyperparameter_sweep.py` ให้เรียก `real_train_func` พร้อมบันทึก summary.csv

## Testing
- `pytest -q` *(ล้มเหลว 7 tests: Line mismatch ใน `tests/test_function_registry.py`)*

------
https://chatgpt.com/codex/tasks/task_e_683f03fe2ce88325bd803b5a9ac2d2ba