### PR TITLE
[Patch v5.2.2] Initialize pynvml in ProjectP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,3 +333,8 @@
 - New/Updated unit tests added for config and registry
 - QA: pytest -q passed (193 tests)
 
+### 2025-07-06
+- [Patch v5.2.2] Initialize pynvml in ProjectP to avoid NameError
+- New/Updated unit tests added for ProjectP
+- QA: pytest -q passed (195 tests)
+

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -2,6 +2,19 @@
 
 from src.config import logger
 import sys
+import logging
+
+# [Patch] Initialize pynvml for GPU status detection
+try:
+    import pynvml
+    pynvml.nvmlInit()
+    nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+except ImportError:  # pragma: no cover - optional dependency
+    pynvml = None
+    nvml_handle = None
+except Exception:  # pragma: no cover - NVML failure fallback
+    nvml_handle = None
+
 from src.main import main
 
 def custom_helper_function():
@@ -16,3 +29,8 @@ if __name__ == '__main__':
     except Exception as e:
         logger.error("เกิดข้อผิดพลาดที่ไม่คาดคิด: %s", str(e), exc_info=True)
         sys.exit(1)
+    else:
+        if 'pynvml' in globals() and nvml_handle:
+            logging.info(f"GPU Initialized: {nvml_handle}")
+        else:
+            logging.info("GPU not available, running on CPU")

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -50,7 +50,7 @@ FUNCTIONS_INFO = [
 
 
 
-    ("ProjectP.py", "custom_helper_function", 7),
+    ("ProjectP.py", "custom_helper_function", 20),
 ]
 
 @pytest.mark.parametrize("path, func_name, expected_lineno", FUNCTIONS_INFO)

--- a/tests/test_projectp_nvml.py
+++ b/tests/test_projectp_nvml.py
@@ -1,0 +1,36 @@
+import builtins
+import importlib
+import runpy
+import types
+import sys
+import logging
+import os
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+
+def test_projectp_import_without_pynvml(monkeypatch):
+    """Module should handle missing pynvml gracefully."""
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'pynvml':
+            raise ImportError('no nvml')
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    monkeypatch.delitem(sys.modules, 'ProjectP', raising=False)
+    module = importlib.import_module('ProjectP')
+    assert module.pynvml is None
+    assert module.nvml_handle is None
+
+
+def test_projectp_main_logs_gpu_status(monkeypatch, caplog):
+    """Running the script should log GPU availability."""
+    dummy_main = lambda: None
+    monkeypatch.setitem(sys.modules, 'src.main', types.SimpleNamespace(main=dummy_main))
+    monkeypatch.setattr(sys, 'argv', ['ProjectP.py'])
+    with caplog.at_level(logging.INFO):
+        runpy.run_path('ProjectP.py', run_name='__main__')
+    assert any('GPU not available' in m for m in caplog.messages)


### PR DESCRIPTION
## Summary
- initialize `pynvml` in ProjectP and log GPU status
- adjust registry line numbers
- add tests for pynvml import and logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f25b8f47883259c91d9f74ef926b6