### PR TITLE
เพิ่ม Progress Bar และยกระดับข้อความสรุปผล

### DIFF
--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -37,12 +37,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1663),
-    ("src/strategy.py", "initialize_time_series_split", 3772),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3775),
-    ("src/strategy.py", "apply_kill_switch", 3778),
-    ("src/strategy.py", "log_trade", 3781),
+    ("src/strategy.py", "initialize_time_series_split", 3789),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3792),
+    ("src/strategy.py", "apply_kill_switch", 3795),
+    ("src/strategy.py", "log_trade", 3798),
     ("src/strategy.py", "calculate_metrics", 2661),
-    ("src/strategy.py", "aggregate_fold_results", 3784),
+    ("src/strategy.py", "aggregate_fold_results", 3801),
     ("ProjectP.py", "custom_helper_function", 20),
 ]
 


### PR DESCRIPTION
## Summary
- ใช้ `tqdm` แสดงแถบความคืบหน้าระหว่างวน Fold
- สรุปผลแต่ละ Fold เป็นระดับ WARNING พร้อม Equity/Winrate/MaxDD
- ปรับหมายเลขบรรทัดที่คาดหวังใน unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f34e6ab90832587c766479fe1487a