### PR TITLE
[Patch v5.3.5] QA logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,3 +420,8 @@
 - New/Updated unit tests added for src.training
 - QA: pytest -q passed
 
+### 2025-07-15
+- [Patch v5.3.5] QA logging: fold summary, NaN/Inf catch, critical alerts
+- New/Updated unit tests added for src.strategy
+- QA: pytest -q passed
+

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -2216,6 +2216,13 @@ def run_backtest_simulation_v34(
                    f"BEs:{be_sl_triggered_count_run}, TSLs:{tsl_triggered_count_run}")
     logging.info(summary_msg)
     logging.info(f"      Equity สุดท้าย: ${equity:.2f} (จาก ${initial_capital_segment:.2f})")
+    if np.isnan(equity) or np.isinf(equity):
+        logging.critical(
+            "[QA][CRITICAL] Final Equity is NaN/Inf! Investigate logic/NaN propagation."
+        )
+    logging.warning(
+        f"[QA][SUMMARY] Fold Finished | Final Equity: ${equity:.2f} | Max DD: {max_drawdown_pct:.2%} | KILL SWITCH: {kill_switch_activated}"
+    )
     logging.info(f"      Blocks: MaxDD={orders_blocked_by_drawdown}, Cooldown={orders_blocked_by_cooldown}, LotScale={orders_lot_scaled}, ML1Skip={orders_skipped_ml_l1}(T={current_meta_threshold_l1:.2f})")
     new_blocks_count = sum(1 for b in blocked_order_log if b.get('reason') in ["HIGH_VOL_INDEX", "HIGH_ATR_LOW_SCORE", "NEG_MACD_BUY", "POS_MACD_SELL", f"SOFT_COOLDOWN_{SOFT_COOLDOWN_LOSS_COUNT}L{SOFT_COOLDOWN_LOOKBACK}T", "SPIKE_GUARD_LONDON"])
     logging.info(f"      Blocks (New v4.6/v4.8): Vol/ATR/MACD/SoftCool/Spike={new_blocks_count}")

--- a/tests/test_fold_summary_logging.py
+++ b/tests/test_fold_summary_logging.py
@@ -1,0 +1,38 @@
+import os, sys
+import pandas as pd
+import logging
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from src import strategy
+
+
+def test_fold_summary_logging(simple_m1_df, caplog):
+    df = simple_m1_df.copy()
+    df['ATR_14_Shifted'] = 0.1
+    df['ATR_14'] = 0.1
+    df['ATR_14_Rolling_Avg'] = 0.1
+    required_extra = [
+        'Trend_Zone', 'Gain_Z', 'MACD_hist', 'MACD_hist_smooth', 'Candle_Speed',
+        'Pattern_Label', 'Entry_Long', 'Entry_Short', 'Trade_Tag', 'Signal_Score',
+        'Trade_Reason', 'Volatility_Index', 'ADX', 'RSI', 'Wick_Ratio',
+        'Candle_Body', 'Candle_Range', 'Gain', 'cluster', 'spike_score', 'session'
+    ]
+    for col in required_extra:
+        df[col] = 0
+    df['Entry_Long'] = 1
+    df.index.name = 'Datetime'
+
+    with caplog.at_level(logging.WARNING):
+        strategy.run_backtest_simulation_v34(
+            df,
+            label='TEST',
+            initial_capital_segment=1000.0,
+            side='BUY',
+            fund_profile={'mm_mode': 'balanced', 'risk': 0.01},
+            fold_config={},
+            current_fold_index=0,
+        )
+
+    assert any('[QA][SUMMARY] Fold Finished' in m for m in caplog.messages)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -39,12 +39,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1663),
-    ("src/strategy.py", "initialize_time_series_split", 3848),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3851),
-    ("src/strategy.py", "apply_kill_switch", 3854),
-    ("src/strategy.py", "log_trade", 3857),
-    ("src/strategy.py", "calculate_metrics", 2661),
-    ("src/strategy.py", "aggregate_fold_results", 3860),
+    ("src/strategy.py", "initialize_time_series_split", 3855),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3858),
+    ("src/strategy.py", "apply_kill_switch", 3861),
+    ("src/strategy.py", "log_trade", 3864),
+    ("src/strategy.py", "calculate_metrics", 2669),
+    ("src/strategy.py", "aggregate_fold_results", 3867),
     ("ProjectP.py", "custom_helper_function", 20),
 ]
 


### PR DESCRIPTION
## Summary
- emit fold summary with kill switch status and equity
- critical alert if final equity becomes NaN or Inf
- adjust expected line numbers in function registry tests
- add test for new summary logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5364c4fc8325bf3f850aa8445798