### PR TITLE
[Patch v5.3.5] Improve OMS logic

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -580,7 +580,7 @@ logging.debug("Setting Backtesting Parameters...")
 N_WALK_FORWARD_SPLITS = 5       # Number of folds for final backtest (increased to 5)
 INITIAL_CAPITAL = 100.0         # Starting capital for simulation
 POINT_VALUE = 0.1               # Value per point for 0.01 lot size
-MAX_CONCURRENT_ORDERS = 5       # Max concurrent orders per side (BUY/SELL)
+MAX_CONCURRENT_ORDERS = 7       # Max concurrent orders per side (BUY/SELL)
 MAX_HOLDING_BARS = 24           # Max bars an order can be held
 COMMISSION_PER_001_LOT = 0.10   # Commission per 0.01 lot (USD)
 SPREAD_POINTS = 2.0             # Fixed spread in points
@@ -616,7 +616,7 @@ logging.debug(f"Session Times (UTC): {SESSION_TIMES_UTC}")
 logging.debug("Setting Fold-Specific Configuration...")
 ENTRY_CONFIG_PER_FOLD = {
     # Fold Index: {Config Dictionary}
-    0: {"sl_multiplier": 2.0, "gain_z_thresh": 0.3, "cooldown_sec": 0, "min_signal_score": MIN_SIGNAL_SCORE_ENTRY, },
+    0: {"sl_multiplier": 2.8, "gain_z_thresh": 0.3, "cooldown_sec": 0, "min_signal_score": MIN_SIGNAL_SCORE_ENTRY, },
     1: {"sl_multiplier": 2.0, "gain_z_thresh": 0.3, "cooldown_sec": 0, "min_signal_score": MIN_SIGNAL_SCORE_ENTRY, },
     2: {"sl_multiplier": 2.0, "gain_z_thresh": 0.3, "cooldown_sec": 0, "min_signal_score": MIN_SIGNAL_SCORE_ENTRY, },
     3: {"sl_multiplier": 2.0, "gain_z_thresh": 0.3, "cooldown_sec": 0, "min_signal_score": MIN_SIGNAL_SCORE_ENTRY, },
@@ -632,7 +632,7 @@ PARTIAL_TP_LEVELS = [           # Define partial TP levels
 ]
 PARTIAL_TP_MOVE_SL_TO_ENTRY = True # Move SL to entry after first partial TP?
 ENABLE_KILL_SWITCH = True       # Enable/disable kill switch mechanism
-KILL_SWITCH_MAX_DD_THRESHOLD = 0.20 # Max drawdown % before activating kill switch
+KILL_SWITCH_MAX_DD_THRESHOLD = 0.25 # Max drawdown % before activating kill switch
 KILL_SWITCH_CONSECUTIVE_LOSSES_THRESHOLD = 7 # Max consecutive losses before activating kill switch
 MAX_DRAWDOWN_THRESHOLD = 0.30   # Max drawdown % threshold to block new orders (e.g., 30%)
 logging.info(f"Kill Switch Enabled: {ENABLE_KILL_SWITCH} (DD > {KILL_SWITCH_MAX_DD_THRESHOLD*100:.0f}%, Losses > {KILL_SWITCH_CONSECUTIVE_LOSSES_THRESHOLD})")

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -39,12 +39,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1663),
-    ("src/strategy.py", "initialize_time_series_split", 3848),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3851),
-    ("src/strategy.py", "apply_kill_switch", 3854),
-    ("src/strategy.py", "log_trade", 3857),
-    ("src/strategy.py", "calculate_metrics", 2661),
-    ("src/strategy.py", "aggregate_fold_results", 3860),
+    ("src/strategy.py", "initialize_time_series_split", 3882),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3885),
+    ("src/strategy.py", "apply_kill_switch", 3888),
+    ("src/strategy.py", "log_trade", 3891),
+    ("src/strategy.py", "calculate_metrics", 2685),
+    ("src/strategy.py", "aggregate_fold_results", 3894),
     ("ProjectP.py", "custom_helper_function", 20),
 ]
 


### PR DESCRIPTION
## Summary
- raise MAX_CONCURRENT order limit to 7
- increase SL multiplier for fold 0 to 2.8
- bump kill switch threshold to 25%
- tweak early exit reversal logic with buffer
- emit QA summary logs for each fold
- add NaN/Inf check for final equity
- update function line references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5338adfc8325ac38a6e16a58d4e8