### PR TITLE
[Patch v5.3.5] Skip loading absent models in FULL_RUN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,3 +437,7 @@
 - QA: pytest -q passed
 
 
+### 2025-07-16
+- [Patch v5.3.5] Skip loading absent models in FULL_RUN
+- New/Updated unit tests added for src.main
+- QA: pytest -q passed (218 tests)


### PR DESCRIPTION
## Summary
- handle dynamic model availability when loading models
- remove redundant model load block
- document changes in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5a4fef6c8325bb73b6cd1632ff38