### PR TITLE
Fix function registry test line numbers

### DIFF
--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -27,13 +27,13 @@ FUNCTIONS_INFO = [
 
 
 
-    ("src/main.py", "parse_arguments", 1786),
-    ("src/main.py", "setup_output_directory", 1791),
-    ("src/main.py", "load_features_from_file", 1796),
-    ("src/main.py", "drop_nan_rows", 1801),
-    ("src/main.py", "convert_to_float32", 1806),
-    ("src/main.py", "run_initial_backtest", 1811),
-    ("src/main.py", "save_final_data", 1816),
+    ("src/main.py", "parse_arguments", 1793),
+    ("src/main.py", "setup_output_directory", 1798),
+    ("src/main.py", "load_features_from_file", 1803),
+    ("src/main.py", "drop_nan_rows", 1808),
+    ("src/main.py", "convert_to_float32", 1813),
+    ("src/main.py", "run_initial_backtest", 1818),
+    ("src/main.py", "save_final_data", 1823),
 
 
 


### PR DESCRIPTION
## Summary
- update expected line numbers for main stubs in tests

## Testing
- `pytest -q`
- `python3 src/main.py` *(terminated early with KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683fc6bfbcfc8325a8f602729b486b3e