### PR TITLE
[Patch v5.3.8] Sync registry tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,11 @@
 - [Patch v5.3.7] Improve Colab detection logic
 - New/Updated unit tests added for src.config
 
+### 2025-08-03
+- [Patch v5.3.8] Update registry line numbers for main stubs
+- New/Updated unit tests added for tests.test_function_registry
+- QA: pytest -q passed (219 tests)
+
 
 
 

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -27,13 +27,13 @@ FUNCTIONS_INFO = [
 
 
 
-    ("src/main.py", "parse_arguments", 1786),
-    ("src/main.py", "setup_output_directory", 1791),
-    ("src/main.py", "load_features_from_file", 1796),
-    ("src/main.py", "drop_nan_rows", 1801),
-    ("src/main.py", "convert_to_float32", 1806),
-    ("src/main.py", "run_initial_backtest", 1811),
-    ("src/main.py", "save_final_data", 1816),
+    ("src/main.py", "parse_arguments", 1793),
+    ("src/main.py", "setup_output_directory", 1798),
+    ("src/main.py", "load_features_from_file", 1803),
+    ("src/main.py", "drop_nan_rows", 1808),
+    ("src/main.py", "convert_to_float32", 1813),
+    ("src/main.py", "run_initial_backtest", 1818),
+    ("src/main.py", "save_final_data", 1823),
 
 
 


### PR DESCRIPTION
## Summary
- update test_function_registry with new line numbers for stub functions
- document changes in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fca70a4e083258d249fbcb157915e