### PR TITLE
Add adaptive signal threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,3 +463,8 @@
 - [Patch v5.3.8] Improve logger propagation and refine is_colab detection
 - New/Updated unit tests added for src.config and tests
 - QA: pytest -q passed (219 tests)
+
+### 2025-06-04
+- [Patch v5.3.9] Adaptive signal score entry threshold with rolling quantile
+- New/Updated unit tests added for src.strategy and tests.test_adaptive_signal_threshold
+- QA: pytest -q passed (224 tests)

--- a/src/config.py
+++ b/src/config.py
@@ -591,6 +591,12 @@ MAX_SLIPPAGE_POINTS = -1.0      # Maximum slippage in points (negative means bet
 # --- Entry/Exit Logic Parameters ---
 logging.debug("Setting Entry/Exit Logic Parameters...")
 MIN_SIGNAL_SCORE_ENTRY = 2.0    # Minimum signal score required to open an order
+# [Patch v5.3.9] Adaptive threshold settings
+ADAPTIVE_SIGNAL_SCORE_WINDOW = 1000   # Bars used for quantile calculation
+ADAPTIVE_SIGNAL_SCORE_QUANTILE = 0.7  # Quantile for threshold (e.g., 70th)
+MIN_SIGNAL_SCORE_ENTRY_MIN = 0.5      # Clamp lower bound
+MIN_SIGNAL_SCORE_ENTRY_MAX = 3.0      # Clamp upper bound
+USE_ADAPTIVE_SIGNAL_SCORE = True
 BASE_TP_MULTIPLIER = 1.8        # Base R-multiple for TP2 (before dynamic adjustment)
 BASE_BE_SL_R_THRESHOLD = 1.0    # Base R-multiple threshold to move SL to Breakeven
 ADAPTIVE_TSL_START_ATR_MULT = 1.5 # ATR multiplier from entry price to start Trailing Stop Loss

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -1091,6 +1091,11 @@ DEFAULT_ADAPTIVE_TSL_LOW_VOL_STEP_R = 0.3
 DEFAULT_ADAPTIVE_TSL_START_ATR_MULT = 1.5
 DEFAULT_ENABLE_SPIKE_GUARD = True
 DEFAULT_MIN_SIGNAL_SCORE_ENTRY = 2.0
+DEFAULT_ADAPTIVE_SIGNAL_SCORE_WINDOW = 1000
+DEFAULT_ADAPTIVE_SIGNAL_SCORE_QUANTILE = 0.7
+DEFAULT_MIN_SIGNAL_SCORE_ENTRY_MIN = 0.5
+DEFAULT_MIN_SIGNAL_SCORE_ENTRY_MAX = 3.0
+DEFAULT_USE_ADAPTIVE_SIGNAL_SCORE = True
 DEFAULT_RECOVERY_MODE_CONSECUTIVE_LOSSES = 4
 DEFAULT_RECOVERY_MODE_LOT_MULTIPLIER = 0.5
 DEFAULT_MIN_LOT_SIZE = 0.01
@@ -1146,6 +1151,11 @@ ADAPTIVE_TSL_LOW_VOL_STEP_R = safe_get_global('ADAPTIVE_TSL_LOW_VOL_STEP_R', DEF
 ADAPTIVE_TSL_START_ATR_MULT = safe_get_global('ADAPTIVE_TSL_START_ATR_MULT', DEFAULT_ADAPTIVE_TSL_START_ATR_MULT)
 ENABLE_SPIKE_GUARD = safe_get_global('ENABLE_SPIKE_GUARD', DEFAULT_ENABLE_SPIKE_GUARD)
 MIN_SIGNAL_SCORE_ENTRY = safe_get_global('MIN_SIGNAL_SCORE_ENTRY', DEFAULT_MIN_SIGNAL_SCORE_ENTRY)
+ADAPTIVE_SIGNAL_SCORE_WINDOW = safe_get_global('ADAPTIVE_SIGNAL_SCORE_WINDOW', DEFAULT_ADAPTIVE_SIGNAL_SCORE_WINDOW)
+ADAPTIVE_SIGNAL_SCORE_QUANTILE = safe_get_global('ADAPTIVE_SIGNAL_SCORE_QUANTILE', DEFAULT_ADAPTIVE_SIGNAL_SCORE_QUANTILE)
+MIN_SIGNAL_SCORE_ENTRY_MIN = safe_get_global('MIN_SIGNAL_SCORE_ENTRY_MIN', DEFAULT_MIN_SIGNAL_SCORE_ENTRY_MIN)
+MIN_SIGNAL_SCORE_ENTRY_MAX = safe_get_global('MIN_SIGNAL_SCORE_ENTRY_MAX', DEFAULT_MIN_SIGNAL_SCORE_ENTRY_MAX)
+USE_ADAPTIVE_SIGNAL_SCORE = safe_get_global('USE_ADAPTIVE_SIGNAL_SCORE', DEFAULT_USE_ADAPTIVE_SIGNAL_SCORE)
 RECOVERY_MODE_CONSECUTIVE_LOSSES = safe_get_global('RECOVERY_MODE_CONSECUTIVE_LOSSES', DEFAULT_RECOVERY_MODE_CONSECUTIVE_LOSSES)
 RECOVERY_MODE_LOT_MULTIPLIER = safe_get_global('RECOVERY_MODE_LOT_MULTIPLIER', DEFAULT_RECOVERY_MODE_LOT_MULTIPLIER)
 MIN_LOT_SIZE = safe_get_global('MIN_LOT_SIZE', DEFAULT_MIN_LOT_SIZE)
@@ -1243,6 +1253,19 @@ def get_adaptive_tsl_step(current_atr, avg_atr, default_step=None):
             return default_step
     except Exception:
         return default_step
+
+# [Patch v5.3.9] Adaptive Signal Score helper
+def get_dynamic_signal_score_entry(df, window=1000, quantile=0.7, min_val=0.5, max_val=3.0):
+    """Return quantile-based signal score threshold with clamp."""
+    if df is None or 'Signal_Score' not in df.columns or len(df) == 0:
+        return min_val
+    scores = df['Signal_Score'].dropna().astype(float)
+    recent_scores = scores.iloc[-window:]
+    if recent_scores.empty:
+        return min_val
+    val = recent_scores.quantile(quantile)
+    val = max(min_val, min(val, max_val))
+    return float(val)
 
 # <<< [Patch] MODIFIED v4.8.8 (Patch 11): Renamed and simplified to only handle TSL >>>
 def update_tsl_only(order, current_high, current_low, current_atr, avg_atr, atr_multiplier=1.5):
@@ -1972,7 +1995,19 @@ def run_backtest_simulation_v34(
             df_sim.loc[current_index, f"Trade_Reason{label_suffix}"] = trade_reason if final_m1_signal != "NONE" else "NONE"
             df_sim.loc[current_index, f"Session{label_suffix}"] = session_tag
             df_sim.loc[current_index, f"Trade_Tag{label_suffix}"] = current_trade_tag
-            entry_allowed, block_reason_entry = is_entry_allowed(row, session_tag, consecutive_losses); open_new_order = False; is_reentry_trade = False; is_forced_entry = False
+            if USE_ADAPTIVE_SIGNAL_SCORE:
+                recent_df = df_sim.iloc[max(0, current_bar_index - ADAPTIVE_SIGNAL_SCORE_WINDOW):current_bar_index]
+                current_thresh = get_dynamic_signal_score_entry(
+                    recent_df,
+                    ADAPTIVE_SIGNAL_SCORE_WINDOW,
+                    ADAPTIVE_SIGNAL_SCORE_QUANTILE,
+                    MIN_SIGNAL_SCORE_ENTRY_MIN,
+                    MIN_SIGNAL_SCORE_ENTRY_MAX,
+                )
+                logging.info(f"[Adaptive] Current Signal_Score threshold: {current_thresh:.2f}")
+            else:
+                current_thresh = MIN_SIGNAL_SCORE_ENTRY
+            entry_allowed, block_reason_entry = is_entry_allowed(row, session_tag, consecutive_losses, signal_score_threshold=current_thresh); open_new_order = False; is_reentry_trade = False; is_forced_entry = False
             if entry_allowed:
                 if (side == "BUY" and final_m1_signal == "BUY") or (side == "SELL" and final_m1_signal == "SELL"):
                     open_new_order = True; logging.debug(f"   Standard Entry Signal detected for {side} at {now}.")

--- a/tests/test_adaptive_signal_threshold.py
+++ b/tests/test_adaptive_signal_threshold.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pandas as pd
+import logging
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from src.strategy import get_dynamic_signal_score_entry
+
+
+def test_dynamic_signal_score_entry_clamps_max():
+    df = pd.DataFrame({'Signal_Score': range(10)})
+    val = get_dynamic_signal_score_entry(df, window=5, quantile=0.8, min_val=0.5, max_val=3.0)
+    assert val == 3.0
+
+
+def test_dynamic_signal_score_entry_clamps_min():
+    df = pd.DataFrame({'Signal_Score': [0.1]*20})
+    val = get_dynamic_signal_score_entry(df, window=10, quantile=0.7, min_val=0.5, max_val=3.0)
+    assert val == 0.5
+
+
+def test_adaptive_threshold_logging(caplog):
+    df = pd.DataFrame({'Signal_Score': [1, 2, 3]})
+    with caplog.at_level(logging.INFO):
+        thresh = get_dynamic_signal_score_entry(df, window=2, quantile=0.5)
+        logging.info(f"[Adaptive] Current Signal_Score threshold: {thresh:.2f}")
+    assert any('[Adaptive] Current Signal_Score threshold' in m for m in caplog.messages)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -38,13 +38,13 @@ FUNCTIONS_INFO = [
 
 
 
-    ("src/strategy.py", "run_backtest_simulation_v34", 1663),
-    ("src/strategy.py", "initialize_time_series_split", 3885),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3888),
-    ("src/strategy.py", "apply_kill_switch", 3891),
-    ("src/strategy.py", "log_trade", 3894),
-    ("src/strategy.py", "calculate_metrics", 2688),
-    ("src/strategy.py", "aggregate_fold_results", 3897),
+    ("src/strategy.py", "run_backtest_simulation_v34", 1687),
+    ("src/strategy.py", "initialize_time_series_split", 3920),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3923),
+    ("src/strategy.py", "apply_kill_switch", 3926),
+    ("src/strategy.py", "log_trade", 3929),
+    ("src/strategy.py", "calculate_metrics", 2723),
+    ("src/strategy.py", "aggregate_fold_results", 3932),
     ("ProjectP.py", "custom_helper_function", 20),
 ]
 


### PR DESCRIPTION
## Summary
- support adaptive Signal_Score threshold using rolling quantile
- add config flags for adaptive logic
- log chosen threshold every bar in strategy
- update function registry tests and add unit tests for adaptive helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fcd86fd588325afe1474c276766d4