### PR TITLE
Add COMPACT_LOG option for concise logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,3 +470,8 @@
 - New/Updated unit tests added for src.adaptive
 - QA: pytest -q passed (219 tests)
 
+### 2025-08-05
+- [Patch v5.4.1] เพิ่มตัวแปร `COMPACT_LOG` เพื่อลดการแสดงผล log
+- Updated README with usage instructions
+- QA: pytest -q passed (224 tests)
+

--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ python profile_backtest.py XAUUSD_M1.csv --rows 10000 --limit 30 --output profil
 ```bash
 python profile_backtest.py XAUUSD_M1.csv --fund AGGRESSIVE --train --train-output models
 ```
+
+## การลดข้อความ Log
+หากต้องการให้โปรแกรมแสดงเฉพาะคำเตือนและสรุปผลแบบย่อ สามารถตั้งค่า
+ตัวแปรสภาพแวดล้อม `COMPACT_LOG=1` ก่อนรัน `ProjectP.py` เช่น
+
+```bash
+COMPACT_LOG=1 python ProjectP.py
+```
+ค่าดังกล่าวจะปรับระดับ log เป็น `WARNING` อัตโนมัติ ทำให้เห็นเฉพาะ
+ข้อความสำคัญและผลลัพธ์สรุปท้ายรัน

--- a/src/config.py
+++ b/src/config.py
@@ -56,8 +56,9 @@ LOG_FILENAME = f'gold_ai_v{__version__}_qa.log'
 
 # ตั้งค่า Logger กลางเพื่อให้โมดูลอื่น ๆ ใช้งานร่วมกัน
 logger = logging.getLogger('NiceGold')
-# [Patch v5.3.9] ปรับระดับ logger ผ่านตัวแปรสภาพแวดล้อม LOG_LEVEL
-_log_level_name = os.environ.get('LOG_LEVEL', 'INFO').upper()
+# [Patch v5.4.1] รองรับโหมด COMPACT_LOG เพื่อลดข้อความที่แสดงบนหน้าจอ
+_compact_log = os.environ.get('COMPACT_LOG', '0') == '1'
+_log_level_name = 'WARNING' if _compact_log else os.environ.get('LOG_LEVEL', 'INFO').upper()
 _log_level = getattr(logging, _log_level_name, logging.INFO)
 logger.setLevel(_log_level)
 formatter = logging.Formatter(

--- a/src/main.py
+++ b/src/main.py
@@ -1562,6 +1562,10 @@ if __name__ == "__main__":
 
         logger.info(f"   เวลาดำเนินการทั้งหมด: {total_duration:.2f} วินาที ({total_duration/60:.2f} นาที).")
         logger.info("--- End of Script ---")
+        # [Patch v5.4.1] สรุปผลแบบย่อสำหรับโหมด COMPACT_LOG
+        logger.warning(
+            f"[SUMMARY] Runtime: {total_duration:.2f}s | Output: {output_dir_final_path or 'N/A'}"
+        )
 
 # === END OF PART 10/12 ===
 # === START OF PART 11/12 ===


### PR DESCRIPTION
## Summary
- support `COMPACT_LOG` environment variable in `src/config.py`
- emit summary log message when run completes
- document COMPACT_LOG usage in README
- note new feature in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fcec6e1848325884ef9be25e94aae