### PR TITLE
[Patch v5.0.24] Improve soft cooldown logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-07-02
+- [Patch v5.0.24] Improve soft cooldown logic
+- New/Updated unit tests added for cooldown_utils
+- QA: pytest -q passed (225 tests)
+
 ### 2025-07-01
 - [Patch v5.3.10] Handle optional models as warnings
 - New/Updated unit tests added for src.main

--- a/src/cooldown_utils.py
+++ b/src/cooldown_utils.py
@@ -4,22 +4,30 @@ from typing import List
 
 
 def is_soft_cooldown_triggered(pnls: List[float], lookback: int = 10, loss_count: int = 3):
-    """Return True if number of losses in the last `lookback` trades >= `loss_count`."""
-    if len(pnls) < lookback:
+    """[Patch v5.0.24] Determine if soft cooldown should activate.
+
+    If fewer than ``lookback`` trades exist, all available PnLs are considered.
+    This ensures early trades can still trigger the cooldown.
+    """
+
+    if not pnls:
         return False, 0
-    recent_losses = sum(1 for p in pnls[-lookback:] if p < 0)
+
+    effective_lookback = min(len(pnls), lookback)
+    recent_losses = sum(1 for p in pnls[-effective_lookback:] if p < 0)
     return recent_losses >= loss_count, recent_losses
 
 
-def step_soft_cooldown(remaining_bars: int) -> int:
-    """[Patch v5.0.20] Decrease soft cooldown bar counter.
+def step_soft_cooldown(remaining_bars: int, step: int = 1) -> int:
+    """[Patch v5.0.24] Decrease soft cooldown bar counter.
 
     Args:
         remaining_bars (int): Current remaining cooldown bars.
+        step (int): Number of bars to decrement per call.
 
     Returns:
         int: Updated remaining bars (never below zero).
     """
     if remaining_bars > 0:
-        return remaining_bars - 1
+        return max(0, remaining_bars - step)
     return 0

--- a/tests/test_soft_cooldown_logic.py
+++ b/tests/test_soft_cooldown_logic.py
@@ -13,12 +13,12 @@ SOFT_COOLDOWN_LOSS_COUNT = 6
 from cooldown_utils import is_soft_cooldown_triggered, step_soft_cooldown
 
 
-def test_soft_cooldown_requires_lookback():
+def test_soft_cooldown_triggers_with_fewer_trades():
     pnl_history = [-1] * SOFT_COOLDOWN_LOSS_COUNT
-    triggered, _ = is_soft_cooldown_triggered(
+    triggered, losses = is_soft_cooldown_triggered(
         pnl_history, SOFT_COOLDOWN_LOOKBACK, SOFT_COOLDOWN_LOSS_COUNT
     )
-    assert not triggered
+    assert triggered and losses == SOFT_COOLDOWN_LOSS_COUNT
 
 
 def test_soft_cooldown_triggers_after_lookback():
@@ -33,3 +33,5 @@ def test_step_soft_cooldown():
     assert step_soft_cooldown(5) == 4
     assert step_soft_cooldown(1) == 0
     assert step_soft_cooldown(0) == 0
+    assert step_soft_cooldown(10, step=5) == 5
+    assert step_soft_cooldown(4, step=5) == 0


### PR DESCRIPTION
## Summary
- refine soft cooldown trigger to use all available PnLs when history is short
- support configurable decrement step for soft cooldown bars
- update tests for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd90741208325b581e5cbb82319d2