### PR TITLE
Add DST-aware session tagging

### DIFF
--- a/src/utils/sessions.py
+++ b/src/utils/sessions.py
@@ -7,8 +7,10 @@ except Exception:  # pragma: no cover - fallback when config import fails
 import pandas as pd
 
 
-def get_session_tag(timestamp, session_times_utc=None):
+def get_session_tag(timestamp, session_times_utc=None, *, session_tz_map=None, naive_tz='UTC'):
     """Return trading session tag for a given timestamp.
+
+    # [Patch] v5.4.4: Added session_tz_map and naive_tz for DST-aware tagging
 
     Parameters
     ----------
@@ -17,6 +19,12 @@ def get_session_tag(timestamp, session_times_utc=None):
     session_times_utc : dict, optional
         Mapping of session names to (start_hour, end_hour) in UTC.
         If None, uses global SESSION_TIMES_UTC when available.
+    session_tz_map : dict, optional
+        Mapping of session names to (timezone, start_hour, end_hour) where the
+        hours are defined in the local timezone of that session. If provided,
+        daylight saving time is handled automatically.
+    naive_tz : str, optional
+        Timezone to assume when ``timestamp`` is naive. Default is ``'UTC'``.
     """
     if session_times_utc is None:
         global SESSION_TIMES_UTC
@@ -34,17 +42,32 @@ def get_session_tag(timestamp, session_times_utc=None):
     try:
         if not isinstance(timestamp, pd.Timestamp):
             timestamp = pd.Timestamp(timestamp)
-        ts_utc = timestamp.tz_convert('UTC') if timestamp.tzinfo else timestamp.tz_localize('UTC')
-        hour = ts_utc.hour
-        sessions = []
-        for name, (start, end) in session_times_utc_local.items():
-            if start <= end:
-                if start <= hour < end:
-                    sessions.append(name)
-            else:
-                if hour >= start or hour < end:
-                    sessions.append(name)
-        return "/".join(sorted(sessions)) if sessions else "Other"
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.tz_localize(naive_tz)
+        if session_tz_map:
+            sessions = []
+            for name, (tz_name, start, end) in session_tz_map.items():
+                ts_local = timestamp.tz_convert(tz_name)
+                hour = ts_local.hour
+                if start <= end:
+                    if start <= hour < end:
+                        sessions.append(name)
+                else:
+                    if hour >= start or hour < end:
+                        sessions.append(name)
+            return "/".join(sorted(sessions)) if sessions else "Other"
+        else:
+            ts_utc = timestamp.tz_convert('UTC')
+            hour = ts_utc.hour
+            sessions = []
+            for name, (start, end) in session_times_utc_local.items():
+                if start <= end:
+                    if start <= hour < end:
+                        sessions.append(name)
+                else:
+                    if hour >= start or hour < end:
+                        sessions.append(name)
+            return "/".join(sorted(sessions)) if sessions else "Other"
     except Exception as e:  # pragma: no cover - unexpected failures
         logger.error(f"   (Error) Error in get_session_tag for {timestamp}: {e}", exc_info=True)
         return "Error_Tagging"

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -40,12 +40,12 @@ FUNCTIONS_INFO = [
 
 
 
-    ("src/strategy.py", "run_backtest_simulation_v34", 1695),
+    ("src/strategy.py", "run_backtest_simulation_v34", 1704),
     ("src/strategy.py", "initialize_time_series_split", 3964),
     ("src/strategy.py", "calculate_forced_entry_logic", 3967),
     ("src/strategy.py", "apply_kill_switch", 3970),
     ("src/strategy.py", "log_trade", 3973),
-    ("src/strategy.py", "calculate_metrics", 2731),
+    ("src/strategy.py", "calculate_metrics", 2740),
     ("src/strategy.py", "aggregate_fold_results", 3976),
     ("ProjectP.py", "custom_helper_function", 20),
 ]

--- a/tests/test_sessions_utils.py
+++ b/tests/test_sessions_utils.py
@@ -30,3 +30,14 @@ def test_get_session_tag_string_and_cross_midnight():
     ts = '2024-01-01 23:00'
     custom = {'Night': (22, 2)}
     assert get_session_tag(ts, custom) == 'Night'
+
+
+def test_get_session_tag_dst_adjustment():
+    ts = pd.Timestamp('2024-01-01 07:30', tz='UTC')
+    tz_map = {
+        'Asia': ('UTC', 0, 8),
+        'London': ('Europe/London', 8, 17),
+        'NY': ('America/New_York', 8, 17),
+    }
+    assert get_session_tag(ts, session_tz_map=tz_map) == 'Asia'
+# DST aware test


### PR DESCRIPTION
## Summary
- support DST-aware timestamps via `session_tz_map` and `naive_tz` in `get_session_tag`
- adjust unit tests for new behaviour and updated strategy line numbers
- minor patch comment for QA

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdbe280548325878001aa46059c68