### PR TITLE
[Patch v5.4.8] Persist SESSION_TIMES_UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -531,3 +531,7 @@ QA: pytest -q passed (219 tests)
 - [Patch v5.4.7] Update line numbers in function registry test
 - New/Updated unit tests added for tests.test_function_registry
 - QA: pytest -q passed (258 tests)
+### 2025-06-04
+- [Patch v5.4.8] Persist default SESSION_TIMES_UTC to suppress repeated warnings
+- New/Updated unit tests added for utils.sessions
+- QA: pytest -q passed (258 tests)

--- a/src/utils/sessions.py
+++ b/src/utils/sessions.py
@@ -11,6 +11,7 @@ def get_session_tag(timestamp, session_times_utc=None, *, session_tz_map=None, n
     """Return trading session tag for a given timestamp.
 
     # [Patch] v5.4.4: Added session_tz_map and naive_tz for DST-aware tagging
+    # [Patch] v5.4.8: Persist default SESSION_TIMES_UTC to suppress repeated warnings
 
     Parameters
     ----------
@@ -33,7 +34,8 @@ def get_session_tag(timestamp, session_times_utc=None, *, session_tz_map=None, n
         except NameError:
             logger.warning(
                 "get_session_tag: Global SESSION_TIMES_UTC not found, using default.")
-            session_times_utc_local = {"Asia": (0, 8), "London": (7, 16), "NY": (13, 21)}
+            SESSION_TIMES_UTC = {"Asia": (0, 8), "London": (7, 16), "NY": (13, 21)}
+            session_times_utc_local = SESSION_TIMES_UTC
     else:
         session_times_utc_local = session_times_utc
 

--- a/tests/test_warning_skip_extra.py
+++ b/tests/test_warning_skip_extra.py
@@ -34,9 +34,11 @@ def test_get_session_tag_nat():
 
 def test_get_session_tag_missing_global(monkeypatch, caplog):
     monkeypatch.delattr(features, 'SESSION_TIMES_UTC', raising=False)
+    from src import utils
+    monkeypatch.delattr(utils.sessions, 'SESSION_TIMES_UTC', raising=False)
     ts = pd.Timestamp('2024-01-01 05:00', tz='UTC')
     with caplog.at_level(logging.WARNING):
-        tag = features.get_session_tag(ts)
+        tag = utils.sessions.get_session_tag(ts)
     assert tag == 'Asia'
     assert any('Global SESSION_TIMES_UTC not found' in msg for msg in caplog.messages)
 


### PR DESCRIPTION
## Summary
- persist `SESSION_TIMES_UTC` default in `get_session_tag`
- adjust test to clear sessions global before calling function
- document patch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffc5285288325806a1079dcba36b1