### PR TITLE
[Patch v5.4.8] Suppress adaptive threshold log spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -531,3 +531,7 @@ QA: pytest -q passed (219 tests)
 - [Patch v5.4.7] Update line numbers in function registry test
 - New/Updated unit tests added for tests.test_function_registry
 - QA: pytest -q passed (258 tests)
+### 2025-06-04
+- [Patch v5.4.8] Suppress duplicate adaptive signal threshold logs
+- New/Updated unit tests added for tests.test_function_registry
+- QA: pytest -q passed (258 tests)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -45,12 +45,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1680),
-    ("src/strategy.py", "initialize_time_series_split", 3976),
-    ("src/strategy.py", "calculate_forced_entry_logic", 3979),
-    ("src/strategy.py", "apply_kill_switch", 3982),
-    ("src/strategy.py", "log_trade", 3985),
-    ("src/strategy.py", "calculate_metrics", 2715),
-    ("src/strategy.py", "aggregate_fold_results", 3988),
+    ("src/strategy.py", "initialize_time_series_split", 3985),
+    ("src/strategy.py", "calculate_forced_entry_logic", 3988),
+    ("src/strategy.py", "apply_kill_switch", 3991),
+    ("src/strategy.py", "log_trade", 3994),
+    ("src/strategy.py", "calculate_metrics", 2724),
+    ("src/strategy.py", "aggregate_fold_results", 3997),
     ("ProjectP.py", "custom_helper_function", 20),
 ]
 


### PR DESCRIPTION
## Summary
- suppress repeated log messages for adaptive Signal_Score threshold
- update function registry test with new expected line numbers
- document changes in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffc76da80832595aacf59c1561581