### PR TITLE
[Patch v5.5.1] Import model switcher function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,3 +548,7 @@ QA: pytest -q passed (219 tests)
 - [Patch v5.5.0] Improve config fallbacks and model file handling
 - New/Updated unit tests added for existing suites
 - QA: pytest -q passed (258 tests)
+### 2025-06-06
+- [Patch v5.5.1] Import model switcher inside main
+- Updated unit tests for line numbers in tests.test_function_registry
+- QA: pytest -q passed (258 tests)

--- a/src/main.py
+++ b/src/main.py
@@ -1158,6 +1158,9 @@ def main(run_mode='FULL_PIPELINE', skip_prepare=False, suffix_from_prev_step=Non
             funds_to_run = {DEFAULT_FUND_NAME: default_profile}
             logging.info(f"\n(Single Fund Mode) กำลังรันสำหรับ Fund Profile: {DEFAULT_FUND_NAME}")
 
+        # [Patch v5.5.1] Import model switcher after models and features are loaded
+        from src.features import select_model_for_trade
+
         for fund_name, fund_profile_config in funds_to_run.items():
             fund_profile_config['name'] = fund_name
             logging.info("\n" + "=" * 20 + f" STARTING FUND: {fund_name} (MM Mode: {fund_profile_config.get('mm_mode', 'N/A')}) " + "=" * 20)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -30,14 +30,14 @@ FUNCTIONS_INFO = [
 
 
 
-# [Patch v5.4.7] Updated expected line numbers
-    ("src/main.py", "parse_arguments", 1851),
-    ("src/main.py", "setup_output_directory", 1856),
-    ("src/main.py", "load_features_from_file", 1861),
-    ("src/main.py", "drop_nan_rows", 1866),
-    ("src/main.py", "convert_to_float32", 1871),
-    ("src/main.py", "run_initial_backtest", 1876),
-    ("src/main.py", "save_final_data", 1881),
+# [Patch v5.5.1] Updated expected line numbers
+    ("src/main.py", "parse_arguments", 1857),
+    ("src/main.py", "setup_output_directory", 1862),
+    ("src/main.py", "load_features_from_file", 1867),
+    ("src/main.py", "drop_nan_rows", 1872),
+    ("src/main.py", "convert_to_float32", 1877),
+    ("src/main.py", "run_initial_backtest", 1882),
+    ("src/main.py", "save_final_data", 1887),
 
 
 


### PR DESCRIPTION
## Summary
- import `select_model_for_trade` inside `main`
- update expected line numbers in function registry tests
- document patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840067de3a883258e0d141906c0bd9c