### PR TITLE
[Patch v5.6.0] Download feature lists when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,4 +577,9 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for strategy helper
 - QA: pytest -q passed
 
+### 2025-06-07
+- [Patch v5.6.0] Download feature lists when missing
+- New/Updated unit tests added for ensure_model_files_exist
+- QA: pytest -q passed (266 tests)
+
 

--- a/src/main.py
+++ b/src/main.py
@@ -62,7 +62,11 @@ from src.strategy import (
     train_and_export_meta_model,
     DriftObserver,
 )
-from src.utils import export_trade_log, download_model_if_missing
+from src.utils import (
+    export_trade_log,
+    download_model_if_missing,
+    download_feature_list_if_missing,
+)
 import pandas as pd
 import numpy as np
 import shutil # For file moving in pipeline mode
@@ -452,6 +456,7 @@ def ensure_model_files_exist(output_dir, base_trade_log_path, base_m1_data_path)
         feature_path = os.path.join(output_dir, feature_file)
         if not (os.path.exists(model_path) and os.path.exists(feature_path)):
             download_model_if_missing(model_path, f"URL_MODEL_{key.upper()}")
+            download_feature_list_if_missing(feature_path, f"URL_FEATURES_{key.upper()}")
             if not os.path.exists(model_path) or not os.path.exists(feature_path):
                 missing_models.append(key)
                 logging.warning(f"Missing model file for '{key}' ({model_file}).")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,6 +2,12 @@
 
 from src.utils.sessions import get_session_tag
 from src.utils.trade_logger import export_trade_log, aggregate_trade_logs
-from src.utils.model_utils import download_model_if_missing
+from src.utils.model_utils import download_model_if_missing, download_feature_list_if_missing
 
-__all__ = ["get_session_tag", "export_trade_log", "aggregate_trade_logs", "download_model_if_missing"]
+__all__ = [
+    "get_session_tag",
+    "export_trade_log",
+    "aggregate_trade_logs",
+    "download_model_if_missing",
+    "download_feature_list_if_missing",
+]

--- a/src/utils/model_utils.py
+++ b/src/utils/model_utils.py
@@ -17,3 +17,18 @@ def download_model_if_missing(model_path, url_env):
         logging.info("(Success) Model downloaded.")
     except Exception as e:
         logging.error(f"(Error) Failed to download model from {url}: {e}")
+
+# [Patch v5.6.0] Utility to download feature list files if missing
+def download_feature_list_if_missing(features_path, url_env):
+    """Download feature list from URL specified in environment variable if missing."""
+    if os.path.exists(features_path):
+        return
+    url = os.getenv(url_env)
+    if not url:
+        return
+    try:
+        logging.info(f"(Info) Downloading feature list from {url}...")
+        urllib.request.urlretrieve(url, features_path)
+        logging.info("(Success) Feature list downloaded.")
+    except Exception as e:
+        logging.error(f"(Error) Failed to download feature list from {url}: {e}")

--- a/tests/test_ensure_model_files_exist.py
+++ b/tests/test_ensure_model_files_exist.py
@@ -74,3 +74,20 @@ def test_placeholder_when_data_missing(tmp_path, monkeypatch):
     assert (out_dir / 'features_spike.json').exists()
     assert (out_dir / 'meta_classifier_cluster.pkl').exists()
     assert (out_dir / 'features_cluster.json').exists()
+
+
+def test_download_feature_lists(tmp_path, monkeypatch):
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+
+    feature_src = tmp_path / 'src_features.json'
+    feature_src.write_text('[]')
+
+    monkeypatch.setenv('URL_FEATURES_SPIKE', f'file://{feature_src}')
+    monkeypatch.setenv('URL_FEATURES_CLUSTER', f'file://{feature_src}')
+    monkeypatch.setattr(main, 'train_and_export_meta_model', lambda **k: ({}, []))
+
+    main.ensure_model_files_exist(str(out_dir), 'log_missing', 'm1_missing')
+
+    assert (out_dir / 'features_spike.json').exists()
+    assert (out_dir / 'features_cluster.json').exists()


### PR DESCRIPTION
## Summary
- auto download feature list json files when not present
- expose `download_feature_list_if_missing` via utils
- test feature list download logic

## Testing
- `pytest tests/test_ensure_model_files_exist.py::test_download_feature_lists -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684018077f148325a308964044090ea6