### PR TITLE
Add alert summary in log analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+### 2025-08-22
+- [Patch v5.5.12] Add alert summary utilities in log_analysis
+- New/Updated unit tests added for tests.test_log_analysis
+- QA: pytest -q passed
+
 ### 2025-08-21
 - [Patch v5.5.9] Add pipeline CLI and threshold optimization script
 - New/Updated unit tests added for tests.test_threshold_optimization, tests.test_main_pipeline_cli

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ from src.log_analysis import (
     calculate_reason_summary,
     calculate_duration_stats,
     calculate_drawdown_stats,
+    parse_alerts,
+    calculate_alert_summary,
 )
 
 logs_df = parse_trade_logs('logs')
@@ -97,5 +99,6 @@ print(summary)
 reason_stats = calculate_reason_summary(logs_df)
 duration = calculate_duration_stats(logs_df)
 drawdown = calculate_drawdown_stats(logs_df)
+alerts = calculate_alert_summary('logs')
 ```
 ฟังก์ชัน `calculate_position_size` ยังช่วยคำนวณขนาดลอตที่เหมาะสมตามทุนและระยะ SL


### PR DESCRIPTION
## Summary
- add `parse_alerts` and `calculate_alert_summary` utilities
- integrate alert count reporting via `compile_log_summary`
- document usage in README
- test warning and critical log detection

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68405819d7f4832581cce053f71f9c2c