### PR TITLE
Improve training config validation

### DIFF
--- a/tests/test_optuna_sweep_new.py
+++ b/tests/test_optuna_sweep_new.py
@@ -1,10 +1,11 @@
 import pandas as pd
 from src.training import optuna_sweep
+import src.config as config
 
 
 def test_optuna_sweep_basic(tmp_path, monkeypatch):
     X = pd.DataFrame({'a': [0, 1, 0, 1], 'b': [1, 0, 1, 0]})
     y = pd.Series([0, 1, 0, 1])
-    monkeypatch.setattr('src.training.optuna', None, raising=False)
+    monkeypatch.setattr(config, 'optuna', None, raising=False)
     params = optuna_sweep(X, y, n_trials=1, output_path=str(tmp_path / 'm.pkl'))
     assert params == {}

--- a/tests/test_training_seed.py
+++ b/tests/test_training_seed.py
@@ -1,9 +1,25 @@
 import os
 import src.training as training
+import pandas as pd
 
 
 def test_real_train_func_accepts_seed(tmp_path):
-    res = training.real_train_func(output_dir=str(tmp_path), seed=123)
+    trade_path = tmp_path / 'trade.csv'
+    m1_path = tmp_path / 'm1.csv'
+    pd.DataFrame({'profit': [1, -1, 2]}).to_csv(trade_path, index=False)
+    pd.DataFrame({
+        'Open': [1, 2, 3],
+        'High': [2, 3, 4],
+        'Low': [0, 1, 2],
+        'Close': [1.5, 2.5, 3.5]
+    }).to_csv(m1_path, index=False)
+
+    res = training.real_train_func(
+        output_dir=str(tmp_path),
+        trade_log_path=str(trade_path),
+        m1_path=str(m1_path),
+        seed=123,
+    )
     assert 'model_path' in res
     assert os.path.exists(res['model_path']['model'])
     assert 'metrics' in res


### PR DESCRIPTION
## Summary
- enforce real data requirement for `real_train_func`
- include `iterations`, `task_type`, and `random_seed` when training CatBoost
- fix optuna sweep test patching
- update seed test to provide dummy CSV files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840757dea188325b90da2779b74f44f