### PR TITLE
ปรับปรุง evaluation และ threshold tuning

### DIFF
--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -1,27 +1,46 @@
 import os
 import json
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Dict
 import numpy as np
 import pandas as pd
 from joblib import load
-from sklearn.metrics import accuracy_score, roc_auc_score, f1_score
+from sklearn.metrics import (
+    accuracy_score,
+    roc_auc_score,
+    f1_score,
+    precision_score,
+    recall_score,
+)
 from src.config import logger
 
 
-def find_best_threshold(proba: Iterable[float], y_true: Iterable[int]) -> Tuple[float, float]:
-    """Find threshold that maximizes F1 score."""
+def find_best_threshold(
+    proba: Iterable[float],
+    y_true: Iterable[int],
+    step: float = 0.05,
+) -> Dict[str, float]:
+    """Find threshold that maximizes F1 score and return summary metrics."""
     proba = np.array(list(proba))
     y_true = np.array(list(y_true))
-    thresholds = np.arange(0.1, 0.9, 0.05)
+    thresholds = np.arange(0.1, 0.9, step)
     best_t = 0.5
     best_s = 0.0
+    best_prec = 0.0
+    best_rec = 0.0
     for t in thresholds:
         preds = (proba >= t).astype(int)
         score = f1_score(y_true, preds)
         if score > best_s:
             best_s = score
             best_t = t
-    return best_t, best_s
+            best_prec = precision_score(y_true, preds, zero_division=0)
+            best_rec = recall_score(y_true, preds, zero_division=0)
+    return {
+        "best_threshold": best_t,
+        "best_f1": best_s,
+        "precision": best_prec,
+        "recall": best_rec,
+    }
 
 
 def evaluate_meta_classifier(model_path: str, validation_path: str, features_path: str | None = None):
@@ -56,12 +75,18 @@ def evaluate_meta_classifier(model_path: str, validation_path: str, features_pat
             features = json.load(f)
         if not isinstance(features, list):
             raise ValueError("Invalid features format")
+    except (FileNotFoundError, ValueError) as e:
+        # [Patch] clearer log when features_path is invalid
+        logger.error("features_path ไม่ถูกต้อง: %s", e)
+        return None
     except Exception as e:
         logger.error(f"Could not load features: {e}")
         return None
 
+    dtype_map = {c: "float32" for c in features}
     try:
-        df = pd.read_csv(validation_path)
+        # [Patch] specify dtype to avoid memory spike
+        df = pd.read_csv(validation_path, dtype=dtype_map, low_memory=False)
     except Exception as e:
         logger.error(f"Failed to load validation data: {e}")
         return None

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -959,10 +959,16 @@ def train_and_export_meta_model(
 
             if enable_threshold_tuning and y_proba_cat_val is not None:
                 try:
-                    best_t, best_s = find_best_threshold(y_proba_cat_val, y_val_cat)
-                    logging.info(f"[Patch] Tuned threshold to {best_t:.2f} (F1={best_s:.3f})")
+                    res = find_best_threshold(y_proba_cat_val, y_val_cat)
+                    best_t = res["best_threshold"]
+                    best_s = res["best_f1"]
+                    logging.info(
+                        f"[Patch] Tuned threshold to {best_t:.2f} (F1={best_s:.3f})"
+                    )
                 except Exception as e_thresh:
-                    logging.warning(f"[Patch] Threshold tuning failed: {e_thresh}")
+                    logging.warning(
+                        f"[Patch] Threshold tuning failed: {e_thresh}"
+                    )
 
             # --- SHAP Analysis on Validation Set ---
             if shap and X_val_cat_for_shap is not None and not X_val_cat_for_shap.empty and cat_model is not None: # Check cat_model exists

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -58,13 +58,13 @@ FUNCTIONS_INFO = [
 
 
 
-    ("src/strategy.py", "run_backtest_simulation_v34", 1827),
-    ("src/strategy.py", "initialize_time_series_split", 4246),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4249),
-    ("src/strategy.py", "apply_kill_switch", 4252),
-    ("src/strategy.py", "log_trade", 4255),
-    ("src/strategy.py", "calculate_metrics", 2995),
-    ("src/strategy.py", "aggregate_fold_results", 4258),
+    ("src/strategy.py", "run_backtest_simulation_v34", 1836),
+    ("src/strategy.py", "initialize_time_series_split", 4255),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4258),
+    ("src/strategy.py", "apply_kill_switch", 4261),
+    ("src/strategy.py", "log_trade", 4264),
+    ("src/strategy.py", "calculate_metrics", 3004),
+    ("src/strategy.py", "aggregate_fold_results", 4267),
 
 
 

--- a/tests/test_threshold_tuning.py
+++ b/tests/test_threshold_tuning.py
@@ -25,9 +25,11 @@ class DummyPool:
 def test_find_best_threshold():
     proba = np.array([0.1, 0.4, 0.6, 0.8])
     y = np.array([0, 0, 1, 1])
-    t, s = find_best_threshold(proba, y)
-    assert t == pytest.approx(0.4)
-    assert s == pytest.approx(1.0)
+    res = find_best_threshold(proba, y)
+    assert res["best_threshold"] == pytest.approx(0.4)
+    assert res["best_f1"] == pytest.approx(1.0)
+    assert res["precision"] == pytest.approx(1.0)
+    assert res["recall"] == pytest.approx(1.0)
 
 
 def test_threshold_tuning_called(tmp_path, monkeypatch):
@@ -48,7 +50,12 @@ def test_threshold_tuning_called(tmp_path, monkeypatch):
     called = {}
     def fake_find(proba, y):
         called['hit'] = True
-        return 0.5, 0.5
+        return {
+            "best_threshold": 0.5,
+            "best_f1": 0.5,
+            "precision": 0.5,
+            "recall": 0.5,
+        }
 
     monkeypatch.setattr(strategy, 'find_best_threshold', fake_find)
     monkeypatch.setattr(strategy, 'USE_GPU_ACCELERATION', False, raising=False)


### PR DESCRIPTION
## Summary
- ปรับ find_best_threshold ให้รับค่า step และคืน metric ต่างๆ
- เพิ่มการตรวจสอบและ log ภาษาไทยใน evaluate_meta_classifier
- ปรับการค้นหา threshold ใน strategy ให้รองรับรูปแบบใหม่
- อัพเดต unit tests ให้สอดคล้อง

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840786a1f748325b43bc72fdca8d523