### PR TITLE
[Patch v5.5.7] Vectorize equity updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -753,5 +753,10 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for strategy and features
 - QA: pytest -q passed
 
+### 2025-06-10
+- [Patch v5.5.7] Vectorize equity and drawdown updates in run_backtest_simulation_v34
+- Updated unit tests line numbers for function registry
+- QA: pytest -q passed (348 tests)
+
 
 \n

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -65,12 +65,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1836),
-    ("src/strategy.py", "initialize_time_series_split", 4256),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4259),
-    ("src/strategy.py", "apply_kill_switch", 4262),
-    ("src/strategy.py", "log_trade", 4265),
-    ("src/strategy.py", "calculate_metrics", 3004),
-    ("src/strategy.py", "aggregate_fold_results", 4268),
+    ("src/strategy.py", "initialize_time_series_split", 4278),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4281),
+    ("src/strategy.py", "apply_kill_switch", 4284),
+    ("src/strategy.py", "log_trade", 4287),
+    ("src/strategy.py", "calculate_metrics", 3026),
+    ("src/strategy.py", "aggregate_fold_results", 4290),
 
 
 


### PR DESCRIPTION
## Summary
- speed up run_backtest_simulation_v34 by preallocating numpy arrays
- adjust tests to updated function line numbers
- document patch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408fde747083258db06731287dc3a5