### PR TITLE
Fix line numbers in unit tests

### DIFF
--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -65,12 +65,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1849),
-    ("src/strategy.py", "initialize_time_series_split", 4291),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4294),
-    ("src/strategy.py", "apply_kill_switch", 4297),
-    ("src/strategy.py", "log_trade", 4300),
+    ("src/strategy.py", "initialize_time_series_split", 4297),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4300),
+    ("src/strategy.py", "apply_kill_switch", 4303),
+    ("src/strategy.py", "log_trade", 4306),
     ("src/strategy.py", "calculate_metrics", 3039),
-    ("src/strategy.py", "aggregate_fold_results", 4303),
+    ("src/strategy.py", "aggregate_fold_results", 4309),
 
 
 


### PR DESCRIPTION
## Summary
- update expected line numbers for strategy helper stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840faf4e4448325b971a61aa3538566