### PR TITLE
Update test line numbers for strategy stubs

### DIFF
--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -65,12 +65,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1849),
-    ("src/strategy.py", "initialize_time_series_split", 4305),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4308),
-    ("src/strategy.py", "apply_kill_switch", 4311),
-    ("src/strategy.py", "log_trade", 4314),
-    ("src/strategy.py", "calculate_metrics", 3049),
-    ("src/strategy.py", "aggregate_fold_results", 4317),
+    ("src/strategy.py", "initialize_time_series_split", 4297),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4300),
+    ("src/strategy.py", "apply_kill_switch", 4303),
+    ("src/strategy.py", "log_trade", 4306),
+    ("src/strategy.py", "calculate_metrics", 3039),
+    ("src/strategy.py", "aggregate_fold_results", 4309),
 
 
 


### PR DESCRIPTION
## Summary
- sync expected line numbers in `test_function_registry`

## Testing
- `pytest tests/test_function_registry.py::test_function_exists -q` *(fails: line mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6840fda658708325b5cb6ee638670032