### PR TITLE
Add debug fake trade option

### DIFF
--- a/src/strategy.py
+++ b/src/strategy.py
@@ -4021,8 +4021,21 @@ def run_all_folds_with_threshold(
 
     # <<< MODIFIED v4.8.1: Handle cases where no trades were logged or no metrics generated >>>
     if not all_trade_logs:
-        logging.error(f"      [Runner {run_label}] (Error) No trades were logged in any fold (L1_Th={l1_thresh_display}). Cannot aggregate results.")
-        return None, None, pd.DataFrame(), pd.DataFrame(), {}, [], None, "N/A", "N/A", 0.0
+        debug_fake_trade = os.getenv("DEBUG_FAKE_TRADE", "0") == "1"
+        if debug_fake_trade:
+            logging.warning(
+                f"      [Runner {run_label}] (Debug) No trades logged; generating fake trade for aggregation."
+            )
+            fake_trade = pd.DataFrame(
+                [{"entry_time": pd.Timestamp.utcnow(), "exit_time": pd.Timestamp.utcnow(), "side": "DEBUG", "profit": 0.0}]
+            )
+            all_trade_logs.append(fake_trade)
+            all_fold_metrics.append({"buy": {}, "sell": {}, "debug_fake_trade": True})
+        else:
+            logging.error(
+                f"      [Runner {run_label}] (Error) No trades were logged in any fold (L1_Th={l1_thresh_display}). Cannot aggregate results."
+            )
+            return None, None, pd.DataFrame(), pd.DataFrame(), {}, [], None, "N/A", "N/A", 0.0
     if not all_fold_metrics:
         logging.error(f"      [Runner {run_label}] (Error) No metrics were generated from any fold (L1_Th={l1_thresh_display}). Cannot aggregate results.")
         return None, None, pd.DataFrame(), pd.DataFrame(), {}, [], None, "N/A", "N/A", 0.0

--- a/tests/test_debug_fake_trade.py
+++ b/tests/test_debug_fake_trade.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pandas as pd
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from src import strategy
+
+
+def test_fake_trade_generated(monkeypatch, tmp_path):
+    os.environ['DEBUG_FAKE_TRADE'] = '1'
+
+    df = pd.DataFrame({
+        'Open': [1]*6,
+        'High': [1]*6,
+        'Low': [1]*6,
+        'Close': [1]*6,
+        'ATR_14_Shifted': [0.1]*6,
+    }, index=pd.date_range('2023-01-01', periods=6, freq='min'))
+
+    def dummy_run(*args, **kwargs):
+        return (df.iloc[:0], pd.DataFrame(), 1000.0, {}, 0.0, {}, [], 'L1', 'L2', False, 0, 0.0)
+
+    monkeypatch.setattr(strategy, 'run_backtest_simulation_v34', dummy_run)
+
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    fund = {'name': 'DBG', 'mm_mode': 'static', 'risk': 1}
+
+    result = strategy.run_all_folds_with_threshold(
+        fund_profile=fund,
+        df_m1_final=df,
+        n_walk_forward_splits=2,
+        output_dir=str(out_dir)
+    )
+
+    trade_log = result[3]
+    assert len(trade_log) == 1
+    assert trade_log.iloc[0]['side'] == 'DEBUG'
+    os.environ.pop('DEBUG_FAKE_TRADE')

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -65,12 +65,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1849),
-    ("src/strategy.py", "initialize_time_series_split", 4297),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4300),
-    ("src/strategy.py", "apply_kill_switch", 4303),
-    ("src/strategy.py", "log_trade", 4306),
-    ("src/strategy.py", "calculate_metrics", 3039),
-    ("src/strategy.py", "aggregate_fold_results", 4309),
+    ("src/strategy.py", "initialize_time_series_split", 4322),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4325),
+    ("src/strategy.py", "apply_kill_switch", 4328),
+    ("src/strategy.py", "log_trade", 4331),
+    ("src/strategy.py", "calculate_metrics", 3053),
+    ("src/strategy.py", "aggregate_fold_results", 4334),
 
 
 


### PR DESCRIPTION
## Summary
- allow fake trade generation when no trades logged via `DEBUG_FAKE_TRADE`
- adjust line expectations in `test_function_registry`
- cover fake trade logic with new `test_debug_fake_trade`

## Testing
- `pytest tests/test_debug_fake_trade.py tests/test_function_registry.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68410120611483258a85e3f2436c7dbc