### PR TITLE
Implement env overrides for thresholds

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -641,12 +641,14 @@ OMS_MAX_DISTANCE_PIPS = 1000.0  # [Patch v5.5.8] Max allowed SL/TP distance
 
 # --- Entry/Exit Logic Parameters ---
 logging.debug("Setting Entry/Exit Logic Parameters...")
-MIN_SIGNAL_SCORE_ENTRY = 1.0    # Minimum signal score required to open an order
+# [Patch] Allow MIN_SIGNAL_SCORE_ENTRY override via environment
+MIN_SIGNAL_SCORE_ENTRY = get_env_float("MIN_SIGNAL_SCORE_ENTRY", 1.0)
 # [Patch v5.3.9] Adaptive threshold settings
 ADAPTIVE_SIGNAL_SCORE_WINDOW = 1000   # Bars used for quantile calculation
 ADAPTIVE_SIGNAL_SCORE_QUANTILE = 0.6  # Quantile for threshold (e.g., 60th)
 MIN_SIGNAL_SCORE_ENTRY_MIN = 0.5      # Clamp lower bound
 MIN_SIGNAL_SCORE_ENTRY_MAX = 3.0      # Clamp upper bound
+MIN_SIGNAL_SCORE_ENTRY = max(MIN_SIGNAL_SCORE_ENTRY_MIN, min(MIN_SIGNAL_SCORE_ENTRY_MAX, MIN_SIGNAL_SCORE_ENTRY))
 USE_ADAPTIVE_SIGNAL_SCORE = True
 BASE_TP_MULTIPLIER = 1.8        # Base R-multiple for TP2 (before dynamic adjustment)
 BASE_BE_SL_R_THRESHOLD = 1.0    # Base R-multiple threshold to move SL to Breakeven

--- a/src/features.py
+++ b/src/features.py
@@ -21,6 +21,7 @@ import gc # For memory management
 from src.utils.gc_utils import maybe_collect
 from functools import lru_cache
 from src.utils.sessions import get_session_tag  # [Patch v5.1.3]
+from src.utils import get_env_float
 
 _rsi_cache = {}  # [Patch v4.8.12] Cache RSIIndicator per period
 _atr_cache = {}  # [Patch v4.8.12] Cache AverageTrueRange per period
@@ -684,15 +685,18 @@ try:
     META_MIN_PROBA_THRESH
 except NameError:
     META_MIN_PROBA_THRESH = DEFAULT_META_MIN_PROBA_THRESH
+META_MIN_PROBA_THRESH = get_env_float("META_MIN_PROBA_THRESH", META_MIN_PROBA_THRESH)  # env override
 try:
     REENTRY_MIN_PROBA_THRESH
 except NameError:
     REENTRY_MIN_PROBA_THRESH = META_MIN_PROBA_THRESH
+REENTRY_MIN_PROBA_THRESH = get_env_float("REENTRY_MIN_PROBA_THRESH", REENTRY_MIN_PROBA_THRESH)  # env override
 # <<< [Patch] Added try-except for Meta-Meta threshold >>>
 try:
     META_META_MIN_PROBA_THRESH
 except NameError:
     META_META_MIN_PROBA_THRESH = DEFAULT_META_META_MIN_PROBA_THRESH
+META_META_MIN_PROBA_THRESH = get_env_float("META_META_MIN_PROBA_THRESH", META_META_MIN_PROBA_THRESH)  # env override
 # <<< End of [Patch] >>>
 try:
     ENABLE_OPTUNA_TUNING

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -43,3 +43,26 @@ def test_config_threshold_env(monkeypatch):
     assert cfg.DRIFT_WASSERSTEIN_THRESHOLD == 0.25
     monkeypatch.delenv('DRIFT_WASSERSTEIN_THRESHOLD', raising=False)
     importlib.reload(cfg)
+
+
+def test_min_signal_score_env(monkeypatch):
+    monkeypatch.setenv("MIN_SIGNAL_SCORE_ENTRY", "0.75")
+    if 'src.config' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'src.config', raising=False)
+    cfg = importlib.import_module('src.config')
+    assert cfg.MIN_SIGNAL_SCORE_ENTRY == 0.75
+    monkeypatch.delenv('MIN_SIGNAL_SCORE_ENTRY', raising=False)
+    importlib.reload(cfg)
+
+
+def test_meta_threshold_env(monkeypatch):
+    monkeypatch.setenv("META_MIN_PROBA_THRESH", "0.4")
+    monkeypatch.setenv("REENTRY_MIN_PROBA_THRESH", "0.35")
+    if 'src.features' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'src.features', raising=False)
+    ft = importlib.import_module('src.features')
+    assert ft.META_MIN_PROBA_THRESH == 0.4
+    assert ft.REENTRY_MIN_PROBA_THRESH == 0.35
+    monkeypatch.delenv('META_MIN_PROBA_THRESH', raising=False)
+    monkeypatch.delenv('REENTRY_MIN_PROBA_THRESH', raising=False)
+    importlib.reload(ft)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -65,12 +65,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1849),
-    ("src/strategy.py", "initialize_time_series_split", 4297),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4300),
-    ("src/strategy.py", "apply_kill_switch", 4303),
-    ("src/strategy.py", "log_trade", 4306),
-    ("src/strategy.py", "calculate_metrics", 3039),
-    ("src/strategy.py", "aggregate_fold_results", 4309),
+    ("src/strategy.py", "initialize_time_series_split", 4328),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4331),
+    ("src/strategy.py", "apply_kill_switch", 4334),
+    ("src/strategy.py", "log_trade", 4337),
+    ("src/strategy.py", "calculate_metrics", 3068),
+    ("src/strategy.py", "aggregate_fold_results", 4340),
 
 
 


### PR DESCRIPTION
## Summary
- allow MIN_SIGNAL_SCORE_ENTRY to be overridden via env variable
- add environment overrides for META_MIN_PROBA_THRESH & REENTRY_MIN_PROBA_THRESH
- support env overrides in tests
- update function registry expected line numbers

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6841013416208325b3c848490a4d821c