### PR TITLE
[Patch v5.7.3] Threshold suggestion when no trades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for tests.test_projectp_cli
 - QA: pytest -q passed (370 tests)
 
+### 2025-10-08
+- [Patch v5.7.3] Suggest relaxing threshold when no trades logged
+- New/Updated unit tests added for tests.test_trade_logger
+- QA: pytest -q passed
+
 ### 2025-10-06
 
 - [Patch v5.6.8] Handle empty trade logs and lower default ML threshold

--- a/src/utils/trade_logger.py
+++ b/src/utils/trade_logger.py
@@ -62,6 +62,18 @@ def export_trade_log(trades, output_dir, label, fund_name=None):
         qa_path = os.path.join(qa_dir, f"{label}_trade_qa.log")
         with open(qa_path, "w", encoding="utf-8") as f:
             f.write("[QA] No trade. Output file generated as EMPTY.\n")
+        suggest_threshold_relaxation(qa_dir, label)
+
+
+def suggest_threshold_relaxation(qa_dir: str, label: str) -> None:
+    """[Patch v5.7.3] Log suggestion to relax ML threshold if no trades found."""
+    os.makedirs(qa_dir, exist_ok=True)
+    suggestion_file = os.path.join(qa_dir, f"relax_threshold_{label}.log")
+    with open(suggestion_file, "w", encoding="utf-8") as f:
+        f.write(
+            "No trades generated. Consider relaxing ML_META_FILTER or entry\n"
+        )
+    logger.info(f"[QA] Threshold relaxation suggestion saved to {suggestion_file}")
 
 
 def aggregate_trade_logs(fold_dirs, output_file, label):

--- a/tests/test_trade_logger.py
+++ b/tests/test_trade_logger.py
@@ -32,9 +32,11 @@ def test_export_trade_log_empty_creates_audit(tmp_path):
     export_trade_log(pd.DataFrame(), str(out_dir), 'L2')
     log_file = out_dir / 'trade_log_L2.csv'
     qa_file = out_dir / 'qa_logs' / 'L2_trade_qa.log'
+    relax_file = out_dir / 'qa_logs' / 'relax_threshold_L2.log'
     assert log_file.exists()
     assert qa_file.exists()
     assert qa_file.read_text() == "[QA] No trade. Output file generated as EMPTY.\n"
+    assert relax_file.exists()
 
 
 def test_aggregate_trade_logs(tmp_path):


### PR DESCRIPTION
## Summary
- add suggestion file when no trades are logged
- test for new suggestion log
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841821fdc54832596bb2b5052539cd5