### PR TITLE
[Patch v5.7.3] Log blocked reasons for empty folds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for tests.test_projectp_cli
 - QA: pytest -q passed (370 tests)
 
+### 2025-10-08
+- [Patch v5.7.3] Log reasons when folds have no trades
+- New/Updated unit tests added for tests.test_empty_summary
+- QA: pytest -q passed
+
 ### 2025-10-06
 
 - [Patch v5.6.8] Handle empty trade logs and lower default ML threshold

--- a/src/log_analysis.py
+++ b/src/log_analysis.py
@@ -182,3 +182,11 @@ def plot_summary(df: pd.DataFrame):
     ax.set_ylabel("value")
     return fig
 
+
+def summarize_block_reasons(blocked_logs: list[dict]) -> pd.Series:
+    """[Patch v5.7.3] Return counts of block reasons from blocked order log."""
+    if not blocked_logs:
+        return pd.Series(dtype=int)
+    reasons = [b.get("reason", "UNKNOWN") for b in blocked_logs if isinstance(b, dict)]
+    return pd.Series(reasons).value_counts()
+

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -31,6 +31,7 @@ from src.cooldown_utils import (
 from itertools import product
 from src.utils.sessions import get_session_tag  # [Patch v5.1.3]
 from src.utils import get_env_float
+from src.log_analysis import summarize_block_reasons  # [Patch v5.7.3]
 from src.config import (
     print_gpu_utilization,  # [Patch v5.2.0] นำเข้า helper สำหรับแสดงการใช้งาน GPU/RAM (print_gpu_utilization)
     USE_MACD_SIGNALS,
@@ -3994,7 +3995,11 @@ def run_all_folds_with_threshold(
         previous_fold_metrics = current_fold_metrics
 
         if log_buy is not None and log_buy.empty and log_sell is not None and log_sell.empty:
-            logging.warning(f"          [SUMMARY] Fold {fold+1} ({fund_name}): No trades opened. All entries blocked.")
+            reason_series = summarize_block_reasons(blocked_buy + blocked_sell)
+            reasons_str = ", ".join(f"{k}:{v}" for k, v in reason_series.items()) if not reason_series.empty else "Unknown"
+            logging.warning(
+                f"          [SUMMARY] Fold {fold+1} ({fund_name}): No trades opened. All entries blocked. Reasons: {reasons_str}"
+            )
 
         fold_duration = time.time() - fold_start_time
         fold_equity = eq_sell

--- a/tests/test_empty_summary.py
+++ b/tests/test_empty_summary.py
@@ -4,7 +4,7 @@ import pandas as pd
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, ROOT_DIR)
 
-from src import strategy
+from src import strategy, log_analysis
 
 
 def test_run_all_folds_handles_no_trades(simple_m1_df, monkeypatch, tmp_path):
@@ -44,3 +44,14 @@ def test_run_all_folds_handles_no_trades(simple_m1_df, monkeypatch, tmp_path):
     metrics_buy, metrics_sell, df_final, trade_log = result[0], result[1], result[2], result[3]
     assert isinstance(metrics_buy, dict)
     assert trade_log.empty
+
+
+def test_summarize_block_reasons():
+    logs = [
+        {"reason": "ML_META_FILTER"},
+        {"reason": "ML_META_FILTER"},
+        {"reason": "SOFT_COOLDOWN"},
+    ]
+    result = log_analysis.summarize_block_reasons(logs)
+    assert result["ML_META_FILTER"] == 2
+    assert result["SOFT_COOLDOWN"] == 1


### PR DESCRIPTION
## Summary
- add `summarize_block_reasons` helper in `log_analysis`
- include block reason counts in fold summary when no trades occurred
- unit test for new helper
- document new patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418266b8bc83258a7f554655377d47