### PR TITLE
Add trade log splitter utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -842,6 +842,11 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for convert_thai_datetime, print_qa_summary, qa_output_default
 - QA: pytest -q passed
 
+### 2025-06-12
+- [Patch v5.7.4] Add trade log splitter utility and side detection
+- New/Updated unit tests added for tests.test_trade_splitter
+- QA: pytest -q passed
+
 
 \n
 ### 2025-06-04

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -9,6 +9,10 @@ from src.utils.trade_logger import (
     log_close_order,
     setup_trade_logger,
 )
+from src.utils.trade_splitter import (
+    split_trade_log,
+    has_buy_sell,
+)
 from src.utils.model_utils import (
     download_model_if_missing,
     download_feature_list_if_missing,
@@ -27,6 +31,8 @@ __all__ = [
     "log_open_order",
     "log_close_order",
     "setup_trade_logger",
+    "split_trade_log",
+    "has_buy_sell",
     "download_model_if_missing",
     "get_env_float",
     "download_feature_list_if_missing",

--- a/src/utils/trade_splitter.py
+++ b/src/utils/trade_splitter.py
@@ -1,0 +1,59 @@
+try:
+    from src.config import logger
+except Exception:
+    import logging
+    logger = logging.getLogger(__name__)
+
+import os
+import pandas as pd
+
+
+def normalize_side(side: object) -> str:
+    """[Patch v5.7.4] Normalize side value to BUY/SELL/NORMAL."""
+    val = str(side).strip().upper()
+    if val in {"BUY", "B", "1"}:
+        return "BUY"
+    if val in {"SELL", "S", "0", "-1"}:
+        return "SELL"
+    return "NORMAL"
+
+
+def has_buy_sell(df: pd.DataFrame) -> bool:
+    """[Patch v5.7.4] Return True if any BUY/SELL rows detected."""
+    sides = df.get("side")
+    if sides is None:
+        return False
+    sides = sides.astype(str).str.strip().str.upper()
+    return sides.isin({"BUY", "SELL", "B", "S", "1", "0", "-1"}).any()
+
+
+def split_trade_log(df: pd.DataFrame, output_dir: str) -> None:
+    """[Patch v5.7.4] Split trade log by side with detailed logging."""
+    os.makedirs(output_dir, exist_ok=True)
+    buy_rows, sell_rows, normal_rows = [], [], []
+    for idx, trade in df.iterrows():
+        side = normalize_side(trade.get("side", ""))
+        if side == "BUY":
+            buy_rows.append(trade)
+            logger.info(f"เขียนไฟล์ trade_log_BUY.csv เลขแถวที่ {idx}")
+        elif side == "SELL":
+            sell_rows.append(trade)
+            logger.info(f"เขียนไฟล์ trade_log_SELL.csv เลขแถวที่ {idx}")
+        else:
+            normal_rows.append(trade)
+            logger.info(f"เขียนไฟล์ trade_log_NORMAL.csv เลขแถวที่ {idx}")
+
+    written = 0
+    if buy_rows:
+        pd.DataFrame(buy_rows).to_csv(os.path.join(output_dir, "trade_log_BUY.csv"), index=False)
+        written += 1
+    if sell_rows:
+        pd.DataFrame(sell_rows).to_csv(os.path.join(output_dir, "trade_log_SELL.csv"), index=False)
+        written += 1
+    if normal_rows:
+        pd.DataFrame(normal_rows).to_csv(os.path.join(output_dir, "trade_log_NORMAL.csv"), index=False)
+        written += 1
+    if written == 0:
+        logger.warning(
+            "[QA-WARNING] ไม่พบรายการใดถูกเขียนลง trade_log_BUY.csv / SELL.csv / NORMAL.csv  กรุณาตรวจสอบเงื่อนไขในโค้ด"
+        )

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -66,12 +66,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1862),
-    ("src/strategy.py", "initialize_time_series_split", 4407),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4410),
-    ("src/strategy.py", "apply_kill_switch", 4413),
-    ("src/strategy.py", "log_trade", 4416),
-    ("src/strategy.py", "calculate_metrics", 3099),
-    ("src/strategy.py", "aggregate_fold_results", 4419),
+    ("src/strategy.py", "initialize_time_series_split", 4459),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4462),
+    ("src/strategy.py", "apply_kill_switch", 4465),
+    ("src/strategy.py", "log_trade", 4468),
+    ("src/strategy.py", "calculate_metrics", 3114),
+    ("src/strategy.py", "aggregate_fold_results", 4471),
 
 
 

--- a/tests/test_trade_splitter.py
+++ b/tests/test_trade_splitter.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import logging
+from src.utils.trade_splitter import split_trade_log, has_buy_sell
+
+
+def test_split_trade_log(tmp_path, caplog):
+    df = pd.DataFrame({
+        'side': ['BUY', 'SELL', 'B', 's', '1', '0', 'HOLD'],
+        'entry_price': [1,1,1,1,1,1,1],
+    })
+    out_dir = tmp_path / 'out'
+    with caplog.at_level(logging.INFO):
+        split_trade_log(df, str(out_dir))
+    assert (out_dir / 'trade_log_BUY.csv').exists()
+    assert (out_dir / 'trade_log_SELL.csv').exists()
+    assert (out_dir / 'trade_log_NORMAL.csv').exists()
+    buy = pd.read_csv(out_dir / 'trade_log_BUY.csv')
+    sell = pd.read_csv(out_dir / 'trade_log_SELL.csv')
+    normal = pd.read_csv(out_dir / 'trade_log_NORMAL.csv')
+    assert len(buy) == 3  # BUY,B,1
+    assert len(sell) == 3  # SELL,s or 0
+    assert len(normal) == 1  # others
+    assert has_buy_sell(df)
+    assert 'trade_log_BUY.csv' in caplog.text
+    assert 'trade_log_SELL.csv' in caplog.text


### PR DESCRIPTION
## Summary
- implement new `trade_splitter` module with `normalize_side`, `has_buy_sell`, and `split_trade_log`
- expose splitter utilities via `src.utils.__init__`
- update expected line numbers in function registry tests
- add tests for trade log splitting logic
- document patch in `CHANGELOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418a5b92c88325b0b1e4995bbbbadb