### PR TITLE
ปรับ CatBoost defaults ตามผล Sweep

### DIFF
--- a/src/strategy.py
+++ b/src/strategy.py
@@ -523,7 +523,7 @@ def train_and_export_meta_model(
             if prelim_model_params is None:
                 prelim_model_params = {
                     'loss_function': 'Logloss', 'eval_metric': 'AUC', 'random_seed': 42, 'verbose': 0,
-                    'iterations': 500, 'learning_rate': 0.05, 'depth': 6, 'l2_leaf_reg': 3,
+                    'iterations': 500, 'learning_rate': 0.05, 'depth': 8, 'l2_leaf_reg': 3,
                     'early_stopping_rounds': 50, 'auto_class_weights': 'Balanced',
                 }
                 logging.info("         (ใช้ Default Prelim Params)")
@@ -861,7 +861,7 @@ def train_and_export_meta_model(
             else:
                 logging.info("         Using Fixed Params (v4.7.1)...")
                 final_model_params_to_use = {
-                    'iterations': 3000, 'learning_rate': 0.01, 'depth': 4, 'l2_leaf_reg': 30,
+                    'iterations': 3000, 'learning_rate': 0.05, 'depth': 8, 'l2_leaf_reg': 3,
                     'eval_metric': "AUC", 'auto_class_weights': "Balanced", 'early_stopping_rounds': early_stopping_rounds,
                     'random_seed': 42, 'verbose': 100, 'loss_function': 'Logloss',
                 }

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -66,12 +66,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1862),
-    ("src/strategy.py", "initialize_time_series_split", 4407),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4410),
-    ("src/strategy.py", "apply_kill_switch", 4413),
-    ("src/strategy.py", "log_trade", 4416),
-    ("src/strategy.py", "calculate_metrics", 3099),
-    ("src/strategy.py", "aggregate_fold_results", 4419),
+    ("src/strategy.py", "initialize_time_series_split", 4459),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4462),
+    ("src/strategy.py", "apply_kill_switch", 4465),
+    ("src/strategy.py", "log_trade", 4468),
+    ("src/strategy.py", "calculate_metrics", 3114),
+    ("src/strategy.py", "aggregate_fold_results", 4471),
 
 
 


### PR DESCRIPTION
## Summary
- ปรับ `prelim_model_params` ให้ใช้ depth=8 ตามค่าที่ได้จากการ sweep
- แก้ `final_model_params_to_use` เป็น learning_rate=0.05, depth=8, l2_leaf_reg=3
- ปรับค่า line number ใน test ให้ตรงกับไฟล์ `src/strategy.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68418a8425148325807af2aa132be517