### PR TITLE
[Patch v5.7.8] Resolve threshold script path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for tests.test_plot_equity_curve_import
 - QA: pytest -q passed (396 tests)
 
+### 2025-10-12
+- [Patch v5.7.8] Resolve absolute path for threshold optimization
+- New/Updated unit tests added for tests.test_projectp_cli::test_run_threshold_uses_absolute_path
+- QA: pytest -q passed
+
 ### 2025-10-09
 
 - [Patch v5.7.5] Extract order management into new module

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -69,7 +69,10 @@ def run_sweep():
 
 def run_threshold():
     """รันการปรับค่า threshold."""
-    subprocess.run([sys.executable, "threshold_optimization.py"], check=True)
+    # [Patch v5.7.8] Resolve threshold script path relative to this file
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    threshold_path = os.path.join(script_dir, "threshold_optimization.py")
+    subprocess.run([sys.executable, threshold_path], check=True)
 
 
 def run_backtest():

--- a/tests/test_projectp_cli.py
+++ b/tests/test_projectp_cli.py
@@ -25,3 +25,18 @@ def test_run_sweep_uses_absolute_path(monkeypatch):
                             'tuning', 'hyperparameter_sweep.py')
     assert called['path'] == expected
     assert os.path.isabs(called['path'])
+
+
+def test_run_threshold_uses_absolute_path(monkeypatch):
+    """run_threshold should build an absolute path to the threshold script."""
+    called = {}
+
+    def fake_run(cmd, check):
+        called['path'] = cmd[1]
+
+    monkeypatch.setattr(proj.subprocess, 'run', fake_run)
+    proj.run_threshold()
+    expected = os.path.join(os.path.dirname(os.path.abspath(proj.__file__)),
+                            'threshold_optimization.py')
+    assert called['path'] == expected
+    assert os.path.isabs(called['path'])


### PR DESCRIPTION
## Summary
- ensure `run_threshold` uses an absolute script path
- add regression test for `run_threshold`
- document patch in CHANGELOG

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a6e942c0832584a7ab7a9793fcc0