### PR TITLE
[Patch v5.7.8] Fix font alias parsing in equity plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2025-10-12
-- [Patch v5.7.8] Handle Matplotlib font alias gracefully in plot
-- New/Updated unit tests added for tests.test_function_registry
+- [Patch v5.7.8] Resolve FontProperties parse error for generic aliases
+- New/Updated unit tests added for tests.test_plot_equity_curve_font
 - QA: pytest -q passed (396 tests)
 
 ### 2025-10-11

--- a/README.md
+++ b/README.md
@@ -163,3 +163,5 @@ fig.savefig('summary.png')
 
 Updated for patch 5.7.3.
 
+Patch 5.7.8 resolves font configuration parsing errors when plotting.
+

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -3544,17 +3544,12 @@ def plot_equity_curve(equity_series_data, title, initial_capital, output_dir, fi
             else current_font_family
         )
         if isinstance(font_family_name, str):
-            if font_family_name.lower() in {
-                "sans-serif",
-                "serif",
-                "cursive",
-                "fantasy",
-                "monospace",
-            }:
+            # [Patch v5.7.8] Use concrete font when generic alias may cause parse errors
+            if font_family_name in {"sans-serif", "serif", "monospace", "cursive", "fantasy"}:
                 fallback_list = plt.rcParams.get(f"font.{font_family_name}", [])
-                font_family_name = fallback_list[0] if fallback_list else None
-            if font_family_name:
-                font_prop = fm.FontProperties(family=font_family_name)
+                if fallback_list:
+                    font_family_name = fallback_list[0]
+            font_prop = fm.FontProperties(family=font_family_name)
     except Exception as e_fontprop:
         logging.warning(
             f"   (Warning) Cannot get FontProperties for plot labels: {e_fontprop}"

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -68,12 +68,12 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1885),
-    ("src/strategy.py", "initialize_time_series_split", 4493),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4496),
-    ("src/strategy.py", "apply_kill_switch", 4499),
-    ("src/strategy.py", "log_trade", 4502),
+    ("src/strategy.py", "initialize_time_series_split", 4488),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4491),
+    ("src/strategy.py", "apply_kill_switch", 4494),
+    ("src/strategy.py", "log_trade", 4497),
     ("src/strategy.py", "calculate_metrics", 3131),
-    ("src/strategy.py", "aggregate_fold_results", 4505),
+    ("src/strategy.py", "aggregate_fold_results", 4500),
 
 
 

--- a/tests/test_plot_equity_curve_font.py
+++ b/tests/test_plot_equity_curve_font.py
@@ -1,0 +1,19 @@
+import importlib
+import os
+import sys
+import pandas as pd
+import matplotlib
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+
+def test_plot_equity_curve_font(tmp_path, monkeypatch):
+    if 'src.main' in sys.modules:
+        del sys.modules['src.main']
+    main = importlib.import_module('src.main')
+    matplotlib.rcParams['font.family'] = ['sans-serif']
+    equity = pd.Series([100, 101], index=pd.date_range('2024-01-01', periods=2, freq='D'))
+    out_dir = tmp_path
+    main.plot_equity_curve(equity, 'FontTest', 100, str(out_dir), 'font_test')
+    assert (out_dir / 'equity_curve_v32_font_test.png').exists()


### PR DESCRIPTION
## Summary
- adjust README with patch notes for 5.7.8
- update changelog entry for patch 5.7.8
- handle Matplotlib generic font aliases gracefully
- align function registry line numbers
- add unit test covering font fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a7465b9c8325acb947529014051f