### PR TITLE
Add dynamic SLTP calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,3 +893,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v5.7.9] Enhance risk management with volatility lot sizing
 - New/Updated unit tests added for tests.test_adaptive, tests.test_trade_logger
 - QA: pytest -q passed
+
+### 2025-06-05
+- [Patch v5.7.9] Add dynamic SL/TP helper
+- New/Updated unit tests added for tests.test_adaptive
+- QA: pytest -q passed (406 tests)

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -19,6 +19,7 @@ from src.adaptive import (
     volatility_adjusted_lot_size,
     dynamic_risk_adjustment,
     check_portfolio_stop,
+    calculate_dynamic_sl_tp,
 )
 import src.features as features
 
@@ -136,3 +137,15 @@ def test_dynamic_risk_adjustment():
 def test_check_portfolio_stop():
     assert check_portfolio_stop(0.12)
     assert not check_portfolio_stop(0.05)
+
+
+def test_calculate_dynamic_sl_tp_cases():
+    sl, tp = calculate_dynamic_sl_tp(2.0, 0.35)
+    assert sl == 3.0 and tp == 9.0
+
+    sl2, tp2 = calculate_dynamic_sl_tp(0.5, 0.55)
+    assert sl2 == 2.0 and tp2 == 3.0
+
+    sl3, tp3 = calculate_dynamic_sl_tp(1.5, 0.45)
+    assert abs(sl3 - 2.25) < 1e-9
+    assert abs(tp3 - 4.5) < 1e-9


### PR DESCRIPTION
## Summary
- introduce `calculate_dynamic_sl_tp` helper in adaptive module
- test dynamic SL/TP scenarios
- document new helper in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b44081508325a54a305f18556d84