### PR TITLE
Fix RSI warning when ta missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- [Patch v5.8.1] Fix RSI warning when 'ta' missing
+- New/Updated unit tests added for tests.test_warning_skip
+- QA: pytest -q passed
+
 - [Patch v5.8.0] Joint Optuna model+strategy optimization
 - New/Updated unit tests added for tests.test_joint_optuna
 - QA: pytest -q passed (407 tests)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -24,12 +24,12 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "validate_csv_data", 1030),
 
 
-    ("src/features.py", "calculate_trend_zone", 1395),
-    ("src/features.py", "tag_price_structure_patterns", 343),
-    ("src/features.py", "create_session_column", 1402),
-    ("src/features.py", "fill_missing_feature_values", 1408),
-    ("src/features.py", "load_feature_config", 1413),
-    ("src/features.py", "calculate_ml_features", 1418),
+    ("src/features.py", "calculate_trend_zone", 1405),
+    ("src/features.py", "tag_price_structure_patterns", 353),
+    ("src/features.py", "create_session_column", 1412),
+    ("src/features.py", "fill_missing_feature_values", 1418),
+    ("src/features.py", "load_feature_config", 1423),
+    ("src/features.py", "calculate_ml_features", 1428),
 
 
 


### PR DESCRIPTION
## Summary
- ensure RSI low-data warning triggers even if 'ta' library missing
- update expected line numbers for features
- document patch in CHANGELOG

## Testing
- `pytest tests/test_warning_skip.py::test_rsi_insufficient_data_logs_warning -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c8a1ea108325a6bf772d4800a125