### PR TITLE
[Patch v5.8.3] Add Config class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,5 +223,6 @@
 - Added `money_management` module for ATR-based SL/TP and portfolio stop logic.
 - Added `wfv_monitor` module for KPI-driven Walk-Forward validation.
 - Added `tuning.joint_optuna` module for joint model + strategy optimization.
+- Added `config` package for environment-based directory paths.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-10-16
+- [Patch v5.8.3] Add Config class for directory setup
+- New/Updated unit tests added for tests.test_config_class
+- QA: pytest -q passed
+
 
 ### 2025-10-15
 - [Patch v5.8.2] Replace deprecated utcnow usage in monitor

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration package."""
+
+from .config import Config, config
+
+__all__ = ["Config", "config"]

--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+
+class Config:
+    """Basic configuration loader with type checking."""
+
+    def __init__(self):
+        self.DATA_DIR = Path(os.getenv("DATA_DIR", "./data"))
+        self.MODEL_DIR = Path(os.getenv("MODEL_DIR", "./models"))
+        self.LOG_DIR = Path(os.getenv("LOG_DIR", "./logs"))
+        self.NUM_WORKERS = self._parse_int("NUM_WORKERS", 1)
+        self.LEARNING_RATE = self._parse_float("LEARNING_RATE", 0.001)
+        self._ensure_dirs()
+
+    @staticmethod
+    def _parse_int(key: str, default: int) -> int:
+        value = os.getenv(key, str(default))
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise TypeError(f"{key} must be int") from exc
+
+    @staticmethod
+    def _parse_float(key: str, default: float) -> float:
+        value = os.getenv(key, str(default))
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise TypeError(f"{key} must be float") from exc
+
+    def _ensure_dirs(self) -> None:
+        for directory in (self.DATA_DIR, self.MODEL_DIR, self.LOG_DIR):
+            directory.mkdir(parents=True, exist_ok=True)
+
+
+config = Config()

--- a/tests/test_config_class.py
+++ b/tests/test_config_class.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+import os
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+
+def _reload_config():
+    if 'config.config' in sys.modules:
+        del sys.modules['config.config']
+    return importlib.import_module('config.config')
+
+
+def test_config_creates_dirs(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATA_DIR', str(tmp_path / 'data'))
+    monkeypatch.setenv('MODEL_DIR', str(tmp_path / 'models'))
+    monkeypatch.setenv('LOG_DIR', str(tmp_path / 'logs'))
+    cfg_module = _reload_config()
+    cfg = cfg_module.Config()
+    assert cfg.DATA_DIR.is_dir()
+    assert cfg.MODEL_DIR.is_dir()
+    assert cfg.LOG_DIR.is_dir()
+
+
+def test_config_numeric_env(monkeypatch):
+    monkeypatch.setenv('NUM_WORKERS', '4')
+    monkeypatch.setenv('LEARNING_RATE', '0.5')
+    monkeypatch.setenv('LOG_DIR', 'tmp_logs')
+    cfg_module = _reload_config()
+    cfg = cfg_module.Config()
+    assert cfg.NUM_WORKERS == 4
+    assert isinstance(cfg.NUM_WORKERS, int)
+    assert cfg.LEARNING_RATE == 0.5
+    assert isinstance(cfg.LEARNING_RATE, float)
+
+
+def test_config_invalid_num(monkeypatch):
+    monkeypatch.setenv('NUM_WORKERS', 'abc')
+    monkeypatch.setenv('LOG_DIR', 'tmp_logs')
+    with pytest.raises(TypeError):
+        _reload_config()


### PR DESCRIPTION
## Summary
- new Config package under `config/`
- create `Config` class for directory and numeric env values
- tests for new Config behavior
- document module in AGENTS and CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d8ab57f083259cb8fc8c8d8b8bf4