### PR TITLE
Configure flake8 and lint checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max_line_length = 88
+exclude = .git,__pycache__,ta,logs,tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
           pip install -r dev-requirements.txt
           pip install -r requirements.txt
       - name: Lint
-        run: flake8
+        run: |
+          black --check .
+          isort --check-only .
+          flake8 src/ strategy/
       - name: Test
         run: pytest --cov=src --cov=strategy --cov-report=html


### PR DESCRIPTION
## Summary
- add project flake8 config
- run black, isort, and flake8 in CI

## Testing
- `pytest -q`
- `pip install -r dev-requirements.txt` *(fails: Could not find black)*

------
https://chatgpt.com/codex/tasks/task_e_68425da8c25883258b2e9c3a26cfd600