### PR TITLE
Add leakage guard utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@
   - Track model drift and notify when retraining is required
   - Provide evaluation utility `evaluate_meta_classifier` in src.evaluation
   - Record daily/weekly AUC metrics using `src.monitor`
-- **Modules:** `src/evaluation.py`, `src/monitor.py`
+- **Modules:** `src/evaluation.py`, `src/monitor.py`, `src/utils/leakage.py`
 
 
 ### [RL_Scalper_AI](src/adaptive.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
 - New/Updated unit tests added for none (packaging update)
 - QA: pytest -q passed (429 tests)
 
+### 2025-06-08
+- [Patch v5.8.3] Add data leakage prevention utilities
+- New/Updated unit tests added for tests.test_leakage
+- QA: pytest -q passed (failed in CI)
+
 ### 2025-06-06
 - [Patch v5.8.5] Add core strategy modules under strategy/
 - New/Updated unit tests added for tests/test_strategy_new_modules.py and tests/test_imports.py

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -26,6 +26,7 @@ from src.utils.resource_plan import get_resource_plan, save_resource_plan
 from src.utils.hardware import estimate_resource_plan
 from src.utils.json_utils import load_json_with_comments
 from src.utils.settings import load_settings, Settings
+from src.utils.leakage import hash_df, timestamp_split, assert_no_overlap
 
 __all__ = [
     "get_session_tag",
@@ -49,6 +50,9 @@ __all__ = [
     "get_resource_plan",
     "save_resource_plan",
     "load_json_with_comments",
+    "hash_df",
+    "timestamp_split",
+    "assert_no_overlap",
     "load_settings",
     "Settings",
 ]

--- a/src/utils/leakage.py
+++ b/src/utils/leakage.py
@@ -1,0 +1,34 @@
+"""Utilities to help prevent data leakage when splitting data."""
+
+from __future__ import annotations
+
+import hashlib
+import pandas as pd
+
+__all__ = ["hash_df", "timestamp_split", "assert_no_overlap"]
+
+
+def hash_df(df: pd.DataFrame) -> str:
+    """Return a hash representing the DataFrame contents."""
+    return hashlib.md5(pd.util.hash_pandas_object(df, index=True).values).hexdigest()
+
+
+def timestamp_split(
+    df: pd.DataFrame,
+    train_start: str,
+    train_end: str,
+    test_start: str,
+    test_end: str,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Split a DataFrame into train and test sets using ``loc`` to avoid leakage."""
+    df_sorted = df.sort_index()
+    train = df_sorted.loc[train_start:train_end].copy()
+    test = df_sorted.loc[test_start:test_end].copy()
+    return train, test
+
+
+def assert_no_overlap(train_df: pd.DataFrame, test_df: pd.DataFrame) -> None:
+    """Raise ``ValueError`` if train/test indices overlap."""
+    overlap = train_df.index.intersection(test_df.index)
+    if not overlap.empty:
+        raise ValueError(f"Data leakage detected: {len(overlap)} overlapping timestamps")

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,0 +1,34 @@
+import sys
+import os
+import pandas as pd
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from src.utils.leakage import hash_df, timestamp_split, assert_no_overlap
+
+
+def test_hash_df_consistent():
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    h1 = hash_df(df)
+    h2 = hash_df(df.copy())
+    assert h1 == h2
+
+
+def test_timestamp_split_and_no_overlap():
+    idx = pd.date_range('2024-01-01', periods=6, freq='D')
+    df = pd.DataFrame({'x': range(6)}, index=idx)
+    train, test = timestamp_split(df, '2024-01-01', '2024-01-03', '2024-01-04', '2024-01-06')
+    assert len(train) == 3
+    assert len(test) == 3
+    assert_no_overlap(train, test)
+
+
+def test_assert_no_overlap_raises():
+    idx = pd.date_range('2024-01-01', periods=4, freq='D')
+    df = pd.DataFrame({'x': range(4)}, index=idx)
+    train = df.iloc[:3]
+    test = df.iloc[2:]
+    with pytest.raises(ValueError):
+        assert_no_overlap(train, test)


### PR DESCRIPTION
## Summary
- implement `hash_df`, `timestamp_split`, `assert_no_overlap`
- expose leakage helpers via `utils` package
- document new module for Model_Inspector
- record patch notes
- add tests for leakage utilities

## Testing
- `pytest -q tests/test_leakage.py`
- `pytest -q` *(fails: 19 failed, 459 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68426cf4afb48325be69721ce3deacb6