### PR TITLE
Implement K-Fold CV utility with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -981,3 +981,7 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests for trade logger and hyperparameter sweep
 - QA: pytest -q passed (429 tests)
 
+### 2025-06-06
+- [Patch v5.8.8] Add k-fold cross validation utility and tests
+- New/Updated unit tests added for tests.test_kfold_cv
+- QA: pytest -q passed (selected tests)

--- a/strategy/plots.py
+++ b/strategy/plots.py
@@ -28,13 +28,14 @@ def plot_equity_curve(trade_df: pd.DataFrame, output_path: Path) -> Path:
 
     output_path.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filepath = output_path / f"equity_{timestamp}.png"
     fig, ax = plt.subplots()
 
-    ax.plot(list(equity))
+    equity = trade_df["Equity"]
+    ax.plot(equity.tolist())
     ax.set_title("Equity Curve")
-    if filepath:
-        fig.savefig(filepath)
-    return ax
+    fig.savefig(filepath)
+    return filepath
 
 
 __all__ = ["plot_equity_curve"]

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -68,14 +68,14 @@ FUNCTIONS_INFO = [
 
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1885),
-    ("src/strategy.py", "initialize_time_series_split", 4503),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4506),
-    ("src/strategy.py", "apply_kill_switch", 4509),
-    ("src/strategy.py", "log_trade", 4512),
+    ("src/strategy.py", "initialize_time_series_split", 4517),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4520),
+    ("src/strategy.py", "apply_kill_switch", 4523),
+    ("src/strategy.py", "log_trade", 4526),
 
     ("src/strategy.py", "calculate_metrics", 3147),
 
-    ("src/strategy.py", "aggregate_fold_results", 4515),
+    ("src/strategy.py", "aggregate_fold_results", 4529),
 
 
 

--- a/tests/test_kfold_cv.py
+++ b/tests/test_kfold_cv.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import sys
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+import src.training as training
+
+
+class DummyModel(LogisticRegression):
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    def fit(self, X, y, eval_set=None, use_best_model=True):
+        return super().fit(X, y)
+
+
+def test_kfold_cv_model_catboost_missing(monkeypatch, caplog):
+    X = pd.DataFrame({'a': [0, 1], 'b': [1, 0]})
+    y = pd.Series([0, 1])
+    monkeypatch.setattr(training, 'CatBoostClassifier', None, raising=False)
+    with caplog.at_level(logging.ERROR):
+        res = training.kfold_cv_model(X, y, model_type='catboost', n_splits=2)
+    assert res == {}
+    assert any('catboost not available' in m for m in caplog.messages)
+
+
+def test_kfold_cv_model_basic(monkeypatch):
+    X = pd.DataFrame({'a': [0, 1, 0, 1], 'b': [1, 0, 1, 0]})
+    y = pd.Series([0, 1, 0, 1])
+    monkeypatch.setattr(training, 'CatBoostClassifier', DummyModel, raising=False)
+    res = training.kfold_cv_model(X, y, model_type='catboost', n_splits=2, early_stopping_rounds=None)
+    assert 'auc' in res and 'f1' in res


### PR DESCRIPTION
## Summary
- add `kfold_cv_model` to run generic K-fold CV
- fix equity curve plotting and return image path
- update function registry expectations
- add unit tests for CV helper
- update changelog

## Testing
- `pytest tests/test_kfold_cv.py tests/test_function_registry.py tests/test_strategy_new_modules.py tests/test_save_model.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68426cb496a083259591b7f6ffb9a769