### PR TITLE
[Patch v5.9.0] Fix drawdown type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### 2025-06-06
+- [Patch v5.9.0] Accept numpy float in update_drawdown
+- New/Updated unit tests added for tests.test_cooldown_state::test_update_drawdown_numpy_float
+- QA: pytest -q passed (504 tests)
+
+### 2025-06-06
 - [Patch v5.8.9] Fix logging capture and plotting APIs
 - New/Updated unit tests added for none (test fixes)
 - QA: pytest -q passed (503 tests)

--- a/src/cooldown_utils.py
+++ b/src/cooldown_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import List
 from dataclasses import dataclass
+import numpy as np
 
 
 @dataclass
@@ -148,7 +149,7 @@ def update_losses(state: CooldownState, pnl: float) -> int:
 def update_drawdown(state: CooldownState, drawdown_pct: float) -> float:
     """[Patch] Update current drawdown percentage."""
 
-    if not isinstance(drawdown_pct, (int, float)):
+    if not isinstance(drawdown_pct, (int, float, np.number)):
         raise TypeError("drawdown_pct must be numeric")
     state.drawdown_pct = float(drawdown_pct)
     return state.drawdown_pct

--- a/tests/test_cooldown_state.py
+++ b/tests/test_cooldown_state.py
@@ -14,6 +14,7 @@ from cooldown_utils import (
     enter_cooldown,
 )
 import pytest
+import numpy as np
 
 def test_debounced_warnings():
     state = CooldownState()
@@ -38,3 +39,11 @@ def test_update_losses_invalid():
     state = CooldownState()
     with pytest.raises(TypeError):
         update_losses(state, "-1")
+
+
+def test_update_drawdown_numpy_float():
+    state = CooldownState()
+    value = np.float64(0.25)
+    result = update_drawdown(state, value)
+    assert isinstance(result, float)
+    assert result == 0.25


### PR DESCRIPTION
## Summary
- allow `update_drawdown` to accept numpy numeric types
- test numpy float support
- update CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428d163720832583262e718deb9ad6