### PR TITLE
Implement cache reset before each WFV fold

### DIFF
--- a/src/features.py
+++ b/src/features.py
@@ -45,6 +45,19 @@ _atr_cache = {}  # [Patch v4.8.12] Cache AverageTrueRange per period
 _sma_cache = {}  # [Patch v4.8.12] Cache SMA results
 _m15_trend_cache = {}
 
+
+def reset_indicator_caches() -> None:
+    """Clear cached indicator objects before each fold.
+
+    ใช้เรียกก่อนเริ่มแต่ละ fold ของ Walk-Forward Validation เพื่อป้องกัน
+    การปนเปื้อนข้อมูลข้ามรอบ (data leakage) จากตัวชี้วัดที่มี state ภายใน.
+    """
+
+    _rsi_cache.clear()
+    _atr_cache.clear()
+    _sma_cache.clear()
+    _m15_trend_cache.clear()
+
 # Ensure global configurations are accessible if run independently
 DEFAULT_ROLLING_Z_WINDOW_M1 = 300; DEFAULT_ATR_ROLLING_AVG_PERIOD = 50
 DEFAULT_PATTERN_BREAKOUT_Z_THRESH = 2.0; DEFAULT_PATTERN_REVERSAL_BODY_RATIO = 0.5
@@ -1669,6 +1682,7 @@ __all__ = [
     "median_filter",
     "bar_range_filter",
     "volume_filter",
+    "reset_indicator_caches",
     "rolling_zscore",
     "tag_price_structure_patterns",
     "calculate_m15_trend_zone",

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -32,6 +32,8 @@ from itertools import product
 from src.utils.sessions import get_session_tag  # [Patch v5.1.3]
 from src.utils import get_env_float, load_json_with_comments
 from src.log_analysis import summarize_block_reasons  # [Patch v5.7.3]
+from src.utils.leakage import assert_no_overlap
+from src.features import reset_indicator_caches
 from src.config import (
     print_gpu_utilization,  # [Patch v5.2.0] นำเข้า helper สำหรับแสดงการใช้งาน GPU/RAM (print_gpu_utilization)
     USE_MACD_SIGNALS,
@@ -3867,6 +3869,8 @@ def run_all_folds_with_threshold(
 
         df_train_fold = df_m1_final.iloc[train_index]
         df_test_fold = df_m1_final.iloc[test_index].copy()
+        assert_no_overlap(df_train_fold, df_test_fold)
+        reset_indicator_caches()
         logging.info(f"          Train period size: {len(df_train_fold)}")
         logging.info(f"          Test period: {df_test_fold.index.min()} to {df_test_fold.index.max()} (Size: {len(df_test_fold)})")
 

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -24,12 +24,12 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "validate_csv_data", 1030),
 
 
-    ("src/features.py", "calculate_trend_zone", 1516),
-    ("src/features.py", "tag_price_structure_patterns", 460),
-    ("src/features.py", "create_session_column", 1523),
-    ("src/features.py", "fill_missing_feature_values", 1529),
-    ("src/features.py", "load_feature_config", 1534),
-    ("src/features.py", "calculate_ml_features", 1539),
+    ("src/features.py", "calculate_trend_zone", 1529),
+    ("src/features.py", "tag_price_structure_patterns", 473),
+    ("src/features.py", "create_session_column", 1536),
+    ("src/features.py", "fill_missing_feature_values", 1542),
+    ("src/features.py", "load_feature_config", 1547),
+    ("src/features.py", "calculate_ml_features", 1552),
 
 
 

--- a/tests/test_indicator_cache.py
+++ b/tests/test_indicator_cache.py
@@ -30,3 +30,13 @@ def test_atr_cache_reuse():
     features.atr(df2, period=14)
     obj_second = features._atr_cache.get(14)
     assert obj_first is obj_second
+
+
+def test_reset_indicator_caches():
+    series = pd.Series(range(20), dtype='float32')
+    features.rsi(series, period=14)
+    assert 14 in features._rsi_cache
+    features.reset_indicator_caches()
+    assert features._rsi_cache == {}
+    assert features._atr_cache == {}
+    assert features._sma_cache == {}


### PR DESCRIPTION
## Summary
- add `reset_indicator_caches` helper in `features`
- call cache reset and assert no overlap in `run_all_folds_with_threshold`
- update expected line numbers in `test_function_registry`
- test cache reset behaviour in `test_indicator_cache`

## Testing
- `python run_tests.py --fast`

------
https://chatgpt.com/codex/tasks/task_e_68428fe93ac08325b6dced7bc4d15f88