### PR TITLE
Add comprehensive tests for log and money management

### DIFF
--- a/tests/test_log_analysis_extra.py
+++ b/tests/test_log_analysis_extra.py
@@ -1,0 +1,73 @@
+import pandas as pd
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from src.log_analysis import (
+    calculate_hourly_summary,
+    calculate_reason_summary,
+    calculate_duration_stats,
+    calculate_drawdown_stats,
+    calculate_expectancy,
+    calculate_alert_summary,
+    compile_log_summary,
+    summarize_block_reasons,
+)
+
+
+def test_summary_functions_on_empty_df(tmp_path):
+    empty_df = pd.DataFrame()
+    summary = calculate_hourly_summary(empty_df)
+    assert list(summary.columns) == ["count", "win_rate", "avg_pnl"]
+    assert summary.empty
+
+    reasons = calculate_reason_summary(empty_df)
+    assert reasons.empty
+
+    duration = calculate_duration_stats(empty_df)
+    assert duration == {"mean": 0.0, "median": 0.0, "max": 0.0}
+
+    stats = calculate_drawdown_stats(empty_df)
+    assert stats == {"total_pnl": 0.0, "max_drawdown": 0.0}
+
+    exp = calculate_expectancy(empty_df)
+    assert exp == 0.0
+
+
+def test_calculate_expectancy_nan_handling():
+    df = pd.DataFrame({"PnL": [1.0, None, float('nan')]})
+    # Only the first value is valid so expectancy should equal that value
+    assert calculate_expectancy(df) == 1.0
+
+
+def test_alert_summary_and_compile(tmp_path):
+    log = tmp_path / "alerts.log"
+    log.write_text("INFO:ok\n")
+    summary = calculate_alert_summary(str(log))
+    assert summary.empty
+
+    df = pd.DataFrame({"EntryTime": [], "CloseTime": [], "PnL": []})
+    comp = compile_log_summary(df, str(log))
+    assert set(comp.keys()) == {"hourly", "reasons", "duration", "pnl", "alerts"}
+    assert comp["alerts"].empty
+
+
+def test_summarize_block_reasons():
+    assert summarize_block_reasons([]).empty
+    logs = [
+        {"reason": "A"},
+        {"reason": "B"},
+        {"reason": "A"},
+        "bad",
+    ]
+    counts = summarize_block_reasons(logs)
+    assert counts.loc["A"] == 2
+    assert counts.loc["B"] == 1
+
+
+def test_calculate_expectancy_all_nan():
+    df = pd.DataFrame({"PnL": [float('nan'), None]})
+    assert calculate_expectancy(df) == 0.0

--- a/tests/test_money_management_extra.py
+++ b/tests/test_money_management_extra.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import math
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from src.money_management import (
+    atr_sl_tp,
+    update_be_trailing,
+    adaptive_position_size,
+    portfolio_hard_stop,
+)
+
+
+def test_atr_sl_tp_invalid_inputs():
+    sl, tp = atr_sl_tp('a', 'b', 'BUY')
+    assert math.isnan(sl) and math.isnan(tp)
+    sl, tp = atr_sl_tp(10.0, -1.0, 'BUY')
+    assert math.isnan(sl) and math.isnan(tp)
+    sl, tp = atr_sl_tp(10.0, 0.5, 'HOLD')
+    assert math.isnan(sl) and math.isnan(tp)
+
+
+def test_update_be_trailing_edge_cases(monkeypatch):
+    assert update_be_trailing(None, 1.0, 1.0, 'BUY') == {}
+
+    bad_order = {'entry_price': 'a', 'sl_price': 1.0}
+    assert update_be_trailing(bad_order, 1.0, 1.0, 'BUY') is bad_order
+
+    calls = {}
+    def fake_trailing(entry, price, atr, side, sl, mult):
+        calls['args'] = (entry, price, atr, side, sl, mult)
+        return price + 0.1
+
+    order = {'entry_price': 10.0, 'sl_price': 10.5, 'be_triggered': False}
+    order = update_be_trailing(order, 9.0, 1.0, 'SELL')
+    assert order['be_triggered'] and order['sl_price'] == 10.0
+
+    monkeypatch.setattr('src.money_management.compute_trailing_atr_stop', fake_trailing)
+    order = update_be_trailing(order, 8.0, 1.0, 'SELL')
+    assert order['sl_price'] == min(10.0, 8.1)
+    assert calls['args'][3] == 'SELL'
+
+
+def test_adaptive_position_size_and_portfolio_stop(monkeypatch):
+    monkeypatch.setattr('src.money_management.atr_position_size', lambda e, a, risk_pct=0.01: (0.5, 1.0))
+    assert adaptive_position_size(1000.0, 0.2) == 0.5
+
+    monkeypatch.setattr('src.money_management.check_portfolio_stop', lambda dd, t: dd >= t)
+    assert portfolio_hard_stop(1000.0, 800.0)
+    assert not portfolio_hard_stop('bad', 800.0)
+    assert not portfolio_hard_stop(-1, 0)


### PR DESCRIPTION
## Summary
- add new test cases covering edge conditions in log_analysis
- add new test cases for money_management edge behaviour

## Testing
- `pytest -q`
- `pytest --disable-warnings --cov=src.log_analysis --cov=src.money_management tests/test_log_analysis.py tests/test_log_analysis_extra.py tests/test_money_management.py tests/test_money_management_extra.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842959e026c832596f0ef19a05487ec