### PR TITLE
[Patch v5.9.3] เพิ่ม helper attempt_order

### DIFF
--- a/tests/test_attempt_order.py
+++ b/tests/test_attempt_order.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import logging
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from src import strategy
+
+
+def test_attempt_order_blocked_oms(monkeypatch, caplog):
+    monkeypatch.setattr(strategy, "OMS_ENABLED", False)
+    with caplog.at_level(logging.WARNING):
+        ok, reasons = strategy.attempt_order("BUY", 1.0, {})
+    assert not ok and reasons == ["OMS_DISABLED"]
+    assert "OMS_DISABLED" in caplog.text
+    monkeypatch.setattr(strategy, "OMS_ENABLED", True)
+
+
+def test_attempt_order_executed(monkeypatch, caplog):
+    monkeypatch.setattr(strategy, "OMS_ENABLED", True)
+    with caplog.at_level(logging.INFO):
+        ok, reasons = strategy.attempt_order("BUY", 1.0, {})
+    assert ok and reasons == []
+    assert "Order Executed" in caplog.text
+
+
+def test_attempt_order_multiple_reasons(monkeypatch, caplog):
+    monkeypatch.setattr(strategy, "OMS_ENABLED", False)
+    params = {"kill_switch_active": True, "paper_mode": True}
+    with caplog.at_level(logging.WARNING):
+        ok, reasons = strategy.attempt_order("SELL", 2.0, params)
+    assert not ok
+    assert reasons[0] == "OMS_DISABLED"
+    assert set(reasons) == {"OMS_DISABLED", "KILL_SWITCH_ACTIVE", "PAPER_MODE_SIMULATION"}


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `attempt_order` ใน `src/strategy.py` เพื่อจัดการเหตุผลการบล็อกออเดอร์และบันทึก log
- สร้างเทส `test_attempt_order.py` ตรวจสอบกรณีถูกบล็อกและถูก Execute

## Testing
- `pytest tests/test_attempt_order.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68429b9162e88325b42bf023ae0ac9b1