### PR TITLE
[Patch vX.Y.Z] Log adaptive threshold changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - QA: pytest -q passed (506 tests)
 
 ### 2025-06-06
+- [Patch vX.Y.Z] Log threshold changes for adaptive signal score
+- New/Updated unit tests added for tests.test_signal_threshold_update
+- QA: pytest -q passed (selected tests)
+
+### 2025-06-06
 - [Patch v5.9.2] Add unit tests for dashboard and evaluation
 - New/Updated unit tests added for tests.test_dashboard_extra2, tests.test_evaluation_extra
 - QA: pytest -q passed (517 tests)

--- a/src/adaptive.py
+++ b/src/adaptive.py
@@ -312,3 +312,47 @@ def calculate_dynamic_sl_tp(
 
     tp = sl * tp_mult
     return sl, tp
+
+
+def update_signal_threshold(current_score: float, params) -> float:
+    """[Patch] Adjust ``signal_score_threshold`` based on ``current_score``.
+
+    หากมีการปรับค่าจะบันทึก Log รูปแบบ
+    ``[Adaptive] Threshold changed | Fold=<…> | Profile=<…> | Old=<…> -> New=<…> | Current Score=<…>``
+    """
+
+    try:
+        score = float(current_score)
+    except (TypeError, ValueError):
+        logger.warning("Invalid current_score for update_signal_threshold")
+        return params.signal_score_threshold
+
+    some_condition = score > 0.8
+    other_condition = score < 0.2
+
+    if some_condition:
+        old_th = params.signal_score_threshold
+        new_th = 0.50
+        params.signal_score_threshold = new_th
+        logger.info(
+            "[Adaptive] Threshold changed | Fold=%s | Profile=%s | Old=%s -> New=%s | Current Score=%.2f",
+            getattr(params, "current_fold", "N/A"),
+            getattr(params, "profile_name", "N/A"),
+            old_th,
+            new_th,
+            score,
+        )
+    elif other_condition:
+        old_th = params.signal_score_threshold
+        new_th = 0.25
+        params.signal_score_threshold = new_th
+        logger.info(
+            "[Adaptive] Threshold changed | Fold=%s | Profile=%s | Old=%s -> New=%s | Current Score=%.2f",
+            getattr(params, "current_fold", "N/A"),
+            getattr(params, "profile_name", "N/A"),
+            old_th,
+            new_th,
+            score,
+        )
+
+    return params.signal_score_threshold

--- a/tests/test_signal_threshold_update.py
+++ b/tests/test_signal_threshold_update.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import logging
+from dataclasses import dataclass
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from src.adaptive import update_signal_threshold
+
+@dataclass
+class DummyParams:
+    signal_score_threshold: float = 0.3
+    current_fold: int = 1
+    profile_name: str = 'Demo'
+
+
+def test_update_signal_threshold_high():
+    params = DummyParams()
+    logger = logging.getLogger('src.adaptive')
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    records = []
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler.emit = lambda record: records.append(record.getMessage())
+    logger.addHandler(handler)
+    try:
+        th = update_signal_threshold(0.9, params)
+    finally:
+        logger.removeHandler(handler)
+    assert th == 0.5
+    assert any('[Adaptive] Threshold changed' in m for m in records)
+
+
+def test_update_signal_threshold_low():
+    params = DummyParams()
+    logger = logging.getLogger('src.adaptive')
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    records = []
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler.emit = lambda record: records.append(record.getMessage())
+    logger.addHandler(handler)
+    try:
+        th = update_signal_threshold(0.1, params)
+    finally:
+        logger.removeHandler(handler)
+    assert th == 0.25
+    assert any('[Adaptive] Threshold changed' in m for m in records)


### PR DESCRIPTION
## Summary
- log adaptive threshold changes in `update_signal_threshold`
- cover new behaviour with unit tests
- document patch in CHANGELOG

## Testing
- `pytest tests/test_signal_threshold_update.py -q`
- `python run_tests.py --fast` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68429ba54d60832586b9d219fcaebb5e