### PR TITLE
[Patch v5.9.8] default sweep log path

### DIFF
--- a/ProjectP.py
+++ b/ProjectP.py
@@ -77,8 +77,14 @@ def _run_script(relative_path: str) -> None:
 def run_hyperparameter_sweep(params: Dict[str, List[float]]) -> None:
     """รันการค้นหาค่าพารามิเตอร์."""
     logger.debug(f"Starting sweep with params: {params}")
-    from tuning.hyperparameter_sweep import run_sweep as _sweep
-    _sweep("sweep_results", params, seed=42, resume=True)
+    from tuning.hyperparameter_sweep import run_sweep as _sweep, DEFAULT_TRADE_LOG
+    _sweep(
+        "sweep_results",
+        params,
+        seed=42,
+        resume=True,
+        trade_log_path=DEFAULT_TRADE_LOG,
+    )
 
 
 def run_sweep():

--- a/tests/test_projectp_cli.py
+++ b/tests/test_projectp_cli.py
@@ -45,14 +45,16 @@ def test_run_threshold_uses_absolute_path(monkeypatch):
 def test_run_hyperparameter_sweep_calls_module(monkeypatch):
     captured = {}
 
-    def fake_sweep(out_dir, params, seed=0, resume=True):
+    def fake_sweep(out_dir, params, seed=0, resume=True, trade_log_path=None, m1_path=None):
         captured['params'] = params
+        captured['trade_log_path'] = trade_log_path
 
     import importlib
     module = importlib.import_module('tuning.hyperparameter_sweep')
     monkeypatch.setattr(module, 'run_sweep', fake_sweep)
     proj.run_hyperparameter_sweep({'lr': [0.1]})
     assert captured['params'] == {'lr': [0.1]}
+    assert captured['trade_log_path'] == module.DEFAULT_TRADE_LOG
 
 
 def test_run_threshold_optimization_calls_module(monkeypatch):


### PR DESCRIPTION
## Summary
- use default trade log when running sweep via ProjectP
- verify ProjectP passes DEFAULT_TRADE_LOG in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d17ae27c8325aee353ad2c27161c