### PR TITLE
[Patch v5.7.4] เพิ่ม unit test hardware

### DIFF
--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -69,17 +69,17 @@ FUNCTIONS_INFO = [
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1948),
 
-    ("src/strategy.py", "initialize_time_series_split", 4613),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4616),
-    ("src/strategy.py", "apply_kill_switch", 4619),
-    ("src/strategy.py", "log_trade", 4622),
+    ("src/strategy.py", "initialize_time_series_split", 4621),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4624),
+    ("src/strategy.py", "apply_kill_switch", 4627),
+    ("src/strategy.py", "log_trade", 4630),
 
-    ("src/strategy.py", "calculate_metrics", 3241),
+    ("src/strategy.py", "calculate_metrics", 3249),
 
-    ("src/strategy.py", "aggregate_fold_results", 4625),
+    ("src/strategy.py", "aggregate_fold_results", 4633),
 
 
-    ("src/strategy.py", "aggregate_fold_results", 4625),
+    ("src/strategy.py", "aggregate_fold_results", 4633),
 
 
 

--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -28,3 +28,54 @@ def test_estimate_resource_plan(monkeypatch):
     plan = hardware.estimate_resource_plan()
     assert plan['n_folds'] >= 4 and plan['batch_size'] >= 16
     monkeypatch.delitem(sys.modules, 'psutil')
+
+
+def test_estimate_plan_gpu(monkeypatch):
+    """GPU available and device name resolved."""
+    fake_psutil = types.SimpleNamespace(virtual_memory=lambda: types.SimpleNamespace(total=16*1024**3))
+    monkeypatch.setitem(sys.modules, 'psutil', fake_psutil)
+    dummy_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(
+            is_available=lambda: True,
+            get_device_name=lambda idx: "RTX"
+        )
+    )
+    monkeypatch.setitem(sys.modules, 'torch', dummy_torch)
+    plan = hardware.estimate_resource_plan()
+    assert plan['gpu'] == "RTX"
+    monkeypatch.delitem(sys.modules, 'psutil')
+    monkeypatch.delitem(sys.modules, 'torch')
+
+
+def test_estimate_plan_gpu_name_error(monkeypatch):
+    """GPU available but device name lookup fails."""
+    fake_psutil = types.SimpleNamespace(virtual_memory=lambda: types.SimpleNamespace(total=16*1024**3))
+    monkeypatch.setitem(sys.modules, 'psutil', fake_psutil)
+    dummy_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(
+            is_available=lambda: True,
+            get_device_name=lambda idx: (_ for _ in ()).throw(RuntimeError("x"))
+        )
+    )
+    monkeypatch.setitem(sys.modules, 'torch', dummy_torch)
+    plan = hardware.estimate_resource_plan()
+    assert plan['gpu'] == "Unknown"
+    monkeypatch.delitem(sys.modules, 'psutil')
+    monkeypatch.delitem(sys.modules, 'torch')
+
+
+def test_estimate_plan_psutil_missing(monkeypatch):
+    """psutil import fails and defaults are returned."""
+    import builtins
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'psutil':
+            raise ImportError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    monkeypatch.setattr(hardware, 'has_gpu', lambda: False)
+    plan = hardware.estimate_resource_plan(default_folds=3, default_batch=15)
+    assert plan == {'n_folds': 3, 'batch_size': 15, 'gpu': 'Unknown'}
+    monkeypatch.setattr(builtins, '__import__', orig_import)


### PR DESCRIPTION
## Summary
- เพิ่ม test ครอบคลุม hardware.py ให้ทุกสาขาโค้ดถูกทดสอบ
- ปรับเลขบรรทัดใน `test_function_registry` ให้ตรงกับไฟล์ strategy ล่าสุด

## Testing
- `pytest -q`
- `coverage run -m pytest tests/unit/test_hardware.py tests/test_hardware_utils.py -q && coverage report -m | grep src/utils/hardware.py`


------
https://chatgpt.com/codex/tasks/task_e_6842d4a30d8c83259885178497ff79e8