### PR TITLE
Fix numpy dependency conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1122,3 +1122,8 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for tests.test_settings
 - QA: pytest -q tests/test_settings.py passed
 
+### 2025-06-08
+- [Patch v5.9.10] Pin numpy version below 2.0
+- New/Updated unit tests added for none (dependency fix)
+- QA: pytest -q reported failures (5 failed, 635 passed)
+

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ python ProjectP.py --mode all
 ### Dependencies
 - Python 3.8-3.10
 - pandas>=2.2.2
-- numpy>=2.0
+- numpy<2.0
 - scikit-learn>=1.6.1
 - catboost>=1.2.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Python >=3.8,<3.11
 pandas==2.2.2
-numpy==2.0.2
+numpy==1.26.4
 scikit-learn==1.6.1
 catboost==1.2.8
 ta==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "pandas==2.2.2",
-        "numpy==2.0.2",
+        "numpy==1.26.4",
         "scikit-learn==1.6.1",
         "catboost==1.2.8",
         "ta==0.11.0",


### PR DESCRIPTION
## Summary
- pin numpy to 1.26.4 for compatibility
- document numpy<2.0 in README
- note new dependency pin in CHANGELOG

## Testing
- `pytest -q` *(fails: 5 failed, 635 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842e13c8bbc8325b5a8d176073c2539