### PR TITLE
Improve wfv_runner unit tests

### DIFF
--- a/tests/test_wfv_runner.py
+++ b/tests/test_wfv_runner.py
@@ -1,7 +1,16 @@
+import logging
 import wfv_runner
 
 
 def test_run_walkforward_logs(caplog):
-    caplog.set_level('INFO')
+    caplog.set_level(logging.INFO)
     wfv_runner.run_walkforward()
     assert any('[Patch] run_walkforward stub executed' in record.message for record in caplog.records)
+
+
+def test_run_walkforward_return_and_log_once(caplog):
+    caplog.set_level(logging.INFO)
+    result = wfv_runner.run_walkforward()
+    assert result is None
+    msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert msgs.count('[Patch] run_walkforward stub executed') == 1


### PR DESCRIPTION
## Summary
- expand unit tests for `wfv_runner`

## Testing
- `python -m pytest tests/test_wfv_runner.py -q`
- `coverage run --source=wfv_runner -m pytest tests/test_wfv_runner.py -q && coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6842e4b0591083258712eaae05faac00