### PR TITLE
เพิ่ม unit tests trend_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-06-09
+- [Patch v5.9.11] Increase coverage of trend_filter
+- New/Updated unit tests added for tests.test_trend_filter
+- QA: pytest -q reported failures (5 failed, 641 passed)
+
 ### 2025-06-06
 - [Patch v5.9.9] Increase coverage of trade_logger to 100%
 - New/Updated unit tests added for tests.test_trade_logger

--- a/tests/test_trend_filter.py
+++ b/tests/test_trend_filter.py
@@ -1,13 +1,51 @@
+import os
+import sys
 import pandas as pd
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT_DIR)
+
 from strategy import trend_filter
 
 
-def test_apply_trend_filter():
-    df = pd.DataFrame({
-        'Trend_Zone': ['UP', 'DOWN', 'NEUTRAL'],
-        'Entry_Long': [1, 1, 1],
-        'Entry_Short': [1, 1, 1],
-    })
+@pytest.mark.parametrize(
+    "trend,expected_long,expected_short",
+    [
+        ("UP", 1, 0),
+        ("DOWN", 0, 1),
+        ("NEUTRAL", 0, 0),
+    ],
+)
+def test_apply_trend_filter(trend, expected_long, expected_short):
+    df = pd.DataFrame(
+        {
+            "Trend_Zone": [trend],
+            "Entry_Long": [1],
+            "Entry_Short": [1],
+        }
+    )
     result = trend_filter.apply_trend_filter(df)
-    assert result['Entry_Long'].tolist() == [1, 0, 0]
-    assert result['Entry_Short'].tolist() == [0, 1, 0]
+    assert result["Entry_Long"].iloc[0] == expected_long
+    assert result["Entry_Short"].iloc[0] == expected_short
+
+
+def test_apply_trend_filter_no_trend_zone():
+    df = pd.DataFrame({"Entry_Long": [1], "Entry_Short": [1]})
+    result = trend_filter.apply_trend_filter(df)
+    # Should return a copy unchanged when Trend_Zone column missing
+    assert result.equals(df)
+    assert result is not df
+
+
+@pytest.mark.parametrize("missing", ["Entry_Long", "Entry_Short"])
+def test_apply_trend_filter_missing_required_columns(missing):
+    df = pd.DataFrame({"Trend_Zone": ["UP"], "Entry_Long": [1], "Entry_Short": [1]})
+    df.drop(columns=[missing], inplace=True)
+    with pytest.raises(KeyError):
+        trend_filter.apply_trend_filter(df)
+
+
+def test_apply_trend_filter_invalid_type():
+    with pytest.raises(TypeError):
+        trend_filter.apply_trend_filter([1, 2, 3])


### PR DESCRIPTION
## Summary
- ปรับปรุง tests/test_trend_filter.py ให้ครอบคลุมทุกเงื่อนไข
- อัปเดต CHANGELOG ระบุ patch v5.9.11

## Testing
- `pytest -q tests/test_trend_filter.py`
- `pytest -q` *(พบการทดสอบล้มเหลวบางส่วน)*

------
https://chatgpt.com/codex/tasks/task_e_6842e4f2a3b08325bc2c96e55b3b1132