### PR TITLE
Improve config test coverage

### DIFF
--- a/tests/test_config_class.py
+++ b/tests/test_config_class.py
@@ -41,3 +41,11 @@ def test_config_invalid_num(monkeypatch):
     monkeypatch.setenv('LOG_DIR', 'tmp_logs')
     with pytest.raises(TypeError):
         _reload_config()
+
+
+def test_config_invalid_float(monkeypatch):
+    """Ensure invalid float env raises TypeError."""
+    monkeypatch.setenv('LEARNING_RATE', 'oops')
+    monkeypatch.setenv('LOG_DIR', 'tmp_logs')
+    with pytest.raises(TypeError):
+        _reload_config()


### PR DESCRIPTION
## Summary
- test float parse error in `Config`

## Testing
- `pytest --cov=config tests/test_config_class.py -q`
- `pytest -q` *(fails: tests failing in model_utils)*

------
https://chatgpt.com/codex/tasks/task_e_684302da2c4c8325adcf89f4c5bcfe66