### PR TITLE
Fix MACD diff precision test

### DIFF
--- a/tests/test_features_more.py
+++ b/tests/test_features_more.py
@@ -44,7 +44,7 @@ def test_macd_with_dummy_ta(monkeypatch):
     line, signal, diff = features.macd(series, window_slow=5, window_fast=2, window_sign=2)
     assert line.iloc[-1] == series.iloc[-1]
     assert signal.iloc[-1] == series.iloc[-1] * 0.5
-    assert diff.iloc[-1] == series.iloc[-1] * 0.1
+    assert np.isclose(diff.iloc[-1], series.iloc[-1] * 0.1)
 
 
 def test_calculate_m15_trend_zone(monkeypatch):


### PR DESCRIPTION
## Summary
- update MACD dummy test to use `np.isclose`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430a38120c8325980fff48593fe7ff