### PR TITLE
Stabilize training tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for tests.test_training_extended
 - QA: pytest -q passed (25 tests)
 
+### 2025-06-06
+- [Patch v5.9.13] Remove xfail markers for stable tests
+- New/Updated unit tests added for none (test markers updated)
+- QA: pytest -q passed (696 tests)
+
 ### 2025-06-09
 - [Patch v5.9.11] Increase coverage of trend_filter
 - New/Updated unit tests added for tests.test_trend_filter

--- a/tests/test_hyperparameter_sweep_cli.py
+++ b/tests/test_hyperparameter_sweep_cli.py
@@ -4,9 +4,17 @@ import pandas as pd
 import pytest
 import logging
 import runpy
+import warnings
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, ROOT_DIR)
+
+# Ignore RuntimeWarning emitted by runpy when module is already imported
+warnings.filterwarnings(
+    "ignore",
+    message=r".*tuning\.hyperparameter_sweep.*",
+    category=RuntimeWarning,
+)
 
 import tuning.hyperparameter_sweep as hs
 
@@ -172,7 +180,9 @@ def test_cli_entrypoint_runs_main(tmp_path, monkeypatch):
 
     monkeypatch.setattr(training, 'real_train_func', dummy_train)
     monkeypatch.setattr(sys, 'argv', ['hyperparameter_sweep.py', '--output_dir', str(tmp_path), '--trade_log_path', str(trade_log)])
-    runpy.run_module('tuning.hyperparameter_sweep', run_name='__main__')
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        runpy.run_module('tuning.hyperparameter_sweep', run_name='__main__')
     assert (tmp_path / 'summary.csv').exists()
 
 

--- a/tests/test_training_more.py
+++ b/tests/test_training_more.py
@@ -124,7 +124,6 @@ class OverfitModel:
         return np.tile([0.6, 0.4], (len(X), 1))
 
 
-@pytest.mark.xfail(reason="unstable in CI")
 def test_kfold_cv_model_overfit(monkeypatch, caplog):
     X = pd.DataFrame({'a': [0, 1, 0, 1, 0, 1, 0, 1], 'b': [1, 0, 1, 0, 1, 0, 1, 0]})
     y = pd.Series([0, 1, 0, 1, 0, 1, 0, 1])
@@ -135,7 +134,6 @@ def test_kfold_cv_model_overfit(monkeypatch, caplog):
     assert any('Overfitting detected' in m for m in caplog.messages)
 
 
-@pytest.mark.xfail(reason="unstable in CI")
 def test_kfold_cv_model_rf_missing(monkeypatch, caplog):
     X = pd.DataFrame({'a': [0, 1], 'b': [1, 0]})
     y = pd.Series([0, 1])
@@ -177,7 +175,6 @@ def test_kfold_cv_model_rf_basic(monkeypatch):
     assert 'auc' in res and 'f1' in res
 
 
-@pytest.mark.xfail(reason="unstable in CI")
 def test_optuna_sweep_success(tmp_path, monkeypatch):
     class Trial:
         def suggest_int(self, name, low, high):
@@ -201,7 +198,6 @@ def test_optuna_sweep_success(tmp_path, monkeypatch):
     assert params == {'n_estimators': 50, 'max_depth': 3}
 
 
-@pytest.mark.xfail(reason="unstable in CI")
 def test_train_lightgbm_mtf_no_files(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(training, 'LGBMClassifier', lambda *a, **k: None, raising=False)
     with caplog.at_level(logging.ERROR):
@@ -210,7 +206,6 @@ def test_train_lightgbm_mtf_no_files(tmp_path, monkeypatch, caplog):
     assert any('M1 or M15 data not found' in m for m in caplog.messages)
 
 
-@pytest.mark.xfail(reason="unstable in CI")
 def test_train_lightgbm_mtf_low_auc(tmp_path, monkeypatch, caplog):
     timestamps = pd.date_range('2024-01-01', periods=5, freq='1min')
     df = pd.DataFrame({


### PR DESCRIPTION
## Summary
- removed xfail marks so tests always run
- suppressed runtime warning in hyperparameter sweep CLI test
- recorded update in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430df3b8b883259455c743b070fc08