### PR TITLE
Improve strategy module test coverage

### DIFF
--- a/tests/unit/test_strategy_orchestration.py
+++ b/tests/unit/test_strategy_orchestration.py
@@ -10,6 +10,11 @@ sys.path.insert(0, ROOT_DIR)
 from strategy import strategy as strategy_module
 
 
+def test_public_api():
+    """Ensure __all__ exports all public functions."""
+    assert sorted(strategy_module.__all__) == ["apply_strategy", "run_backtest"]
+
+
 def test_apply_strategy_adds_columns(monkeypatch):
     df = pd.DataFrame({"Close": [1, 2, 3]})
     monkeypatch.setattr(strategy_module, "generate_open_signals", lambda x: np.array([1, 0, 1]))


### PR DESCRIPTION
## Summary
- add test to validate `__all__` exports for the strategy package

## Testing
- `python run_tests.py --fast`
- `pytest -q tests/unit/test_strategy_orchestration.py --cov=strategy --cov-branch -s`

------
https://chatgpt.com/codex/tasks/task_e_6843132baa448325953ceaaab751fe7e