### PR TITLE
เพิ่มชุดทดสอบ wfv ครบถ้วน

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### 2025-06-06
+- [Patch v5.9.15] Add wfv unit tests
+- New/Updated unit tests added for tests.test_wfv_full
+- QA: pytest -q passed (11 tests)
 - [Patch v5.9.13] Improve coverage to 70%
 - New/Updated unit tests added for tests.test_signal_classifier_additional
 - QA: pytest -q passed (698 tests)

--- a/tests/test_optuna_wfv.py
+++ b/tests/test_optuna_wfv.py
@@ -1,10 +1,25 @@
-import os, sys
+import os
+import sys
+import types
+import importlib.util
 import pandas as pd
 import pytest
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, ROOT_DIR)
-import src.config as config
-from src.wfv import optuna_walk_forward, optuna_walk_forward_per_fold
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+def load_wfv():
+    spec = importlib.util.spec_from_file_location(
+        "src.wfv", os.path.join(ROOT_DIR, "src", "wfv.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.wfv"] = module
+    spec.loader.exec_module(module)
+    return module
+
+import optuna
+
+config = types.SimpleNamespace(optuna=optuna)
+sys.modules["src.config"] = config
 
 
 def dummy_backtest(df, signal=1.0, loss_thresh=4, atr_mult=1.0, ma_period=20):
@@ -14,31 +29,35 @@ def dummy_backtest(df, signal=1.0, loss_thresh=4, atr_mult=1.0, ma_period=20):
 
 
 def test_optuna_walk_forward_basic():
+    wfv = load_wfv()
     df = pd.DataFrame({'Close': range(12)}, index=pd.RangeIndex(12))
     space = {'signal': (0.5, 1.0, 0.5)}
-    res = optuna_walk_forward(df, space, dummy_backtest, train_window=4, test_window=2, step=2, n_trials=1)
+    res = wfv.optuna_walk_forward(df, space, dummy_backtest, train_window=4, test_window=2, step=2, n_trials=1)
     assert 'signal' in res.columns
     assert 'value' in res.columns
 
 
 def test_optuna_walk_forward_no_optuna(monkeypatch):
+    wfv = load_wfv()
     df = pd.DataFrame({'Close': range(12)}, index=pd.RangeIndex(12))
     space = {'signal': (0.5, 1.0, 0.5)}
     monkeypatch.setattr(config, 'optuna', None, raising=False)
-    res = optuna_walk_forward(df, space, dummy_backtest, train_window=4, test_window=2, step=2, n_trials=1)
+    res = wfv.optuna_walk_forward(df, space, dummy_backtest, train_window=4, test_window=2, step=2, n_trials=1)
     assert res.empty
 
 
 def test_optuna_walk_forward_per_fold_basic():
+    wfv = load_wfv()
     df = pd.DataFrame({'Close': range(12)}, index=pd.RangeIndex(12))
     space = {'signal': (0.5, 1.0, 0.5)}
-    res = optuna_walk_forward_per_fold(df, space, dummy_backtest, train_window=4, test_window=2, step=2, n_trials=1)
+    res = wfv.optuna_walk_forward_per_fold(df, space, dummy_backtest, train_window=4, test_window=2, step=2, n_trials=1)
     assert not res.empty
     assert 'fold' in res.columns
 
 
 def test_optuna_walk_forward_per_fold_overlap_error():
+    wfv = load_wfv()
     df = pd.DataFrame({'Close': range(6)}, index=[0, 2, 1, 3, 4, 5])
     space = {'signal': (0.5, 1.0, 0.5)}
     with pytest.raises(AssertionError):
-        optuna_walk_forward_per_fold(df, space, dummy_backtest, train_window=4, test_window=1, step=1, n_trials=1)
+        wfv.optuna_walk_forward_per_fold(df, space, dummy_backtest, train_window=4, test_window=1, step=1, n_trials=1)

--- a/tests/test_wfv_full.py
+++ b/tests/test_wfv_full.py
@@ -1,0 +1,72 @@
+import importlib.util
+import os
+import sys
+import types
+import pandas as pd
+import pytest
+
+def load_wfv():
+    spec = importlib.util.spec_from_file_location(
+        "src.wfv", os.path.join(os.path.dirname(__file__), "..", "src", "wfv.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.wfv"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_grid_search_selects_best_candidate():
+    wfv = load_wfv()
+    df = pd.DataFrame({"Close": range(8)})
+    grid = {"tp": [1, 2]}
+
+    def bt(_df, tp=1):
+        # pnl higher and drawdown lower for tp=2
+        return {"pnl": tp * 2.0, "winrate": 0.6, "maxdd": 1.0 / tp}
+
+    res = wfv.walk_forward_grid_search(
+        df,
+        grid,
+        bt,
+        train_window=4,
+        test_window=2,
+        step=2,
+        objective_metrics=["pnl", "maxdd"],
+    )
+    assert res["tp"].iloc[0] == 2
+
+
+def test_prune_features_no_drop():
+    wfv = load_wfv()
+    df = pd.DataFrame({"a": [1], "b": [2]})
+    imp = {"a": 0.5, "b": 0.3}
+    new_df, dropped = wfv.prune_features_by_importance(df, imp, threshold=0.1)
+    assert dropped == []
+    assert list(new_df.columns) == ["a", "b"]
+
+
+def test_optuna_fold_overlap_error():
+    wfv = load_wfv()
+    df = pd.DataFrame({"Close": range(6)}, index=[0, 1, 2, 2, 3, 4])
+    space = {"signal": (0.5, 1.0, 0.5)}
+    import optuna
+
+    config = types.SimpleNamespace(optuna=optuna)
+    sys_modules_backup = sys.modules.get("src.config")
+    sys.modules["src.config"] = config
+    try:
+        with pytest.raises(ValueError):
+            wfv.optuna_walk_forward_per_fold(
+                df,
+                space,
+                lambda d, **p: {"pnl": 1.0},
+                train_window=3,
+                test_window=2,
+                step=1,
+                n_trials=1,
+            )
+    finally:
+        if sys_modules_backup is not None:
+            sys.modules["src.config"] = sys_modules_backup
+        else:
+            del sys.modules["src.config"]

--- a/tests/test_wfv_utils_extra.py
+++ b/tests/test_wfv_utils_extra.py
@@ -1,25 +1,38 @@
 import pandas as pd
 import pytest
 
-from src import wfv
-from src.wfv import _is_minimize_metric, _dominates, walk_forward_grid_search, prune_features_by_importance
+import importlib.util
+import os
+import sys
+
+def load_wfv():
+    spec = importlib.util.spec_from_file_location(
+        "src.wfv", os.path.join(os.path.dirname(__file__), "..", "src", "wfv.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.wfv"] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_is_minimize_metric_variants():
-    assert _is_minimize_metric("maxdd")
-    assert _is_minimize_metric("EQUITY_DD")
-    assert not _is_minimize_metric("pnl")
+    wfv = load_wfv()
+    assert wfv._is_minimize_metric("maxdd")
+    assert wfv._is_minimize_metric("EQUITY_DD")
+    assert not wfv._is_minimize_metric("pnl")
 
 
 def test_dominates_basic_logic():
+    wfv = load_wfv()
     a = {"pnl": 10.0, "maxdd": 0.1}
     b = {"pnl": 8.0, "maxdd": 0.2}
     metrics = ["pnl", "maxdd"]
-    assert _dominates(a, b, metrics)
-    assert not _dominates(b, a, metrics)
+    assert wfv._dominates(a, b, metrics)
+    assert not wfv._dominates(b, a, metrics)
 
 
 def test_grid_search_fallback_first_candidate(monkeypatch):
+    wfv = load_wfv()
     df = pd.DataFrame({"Close": range(10)})
     grid = {"tp": [1, 2], "sl": [1, 2]}
 
@@ -27,13 +40,14 @@ def test_grid_search_fallback_first_candidate(monkeypatch):
         return {"pnl": 1.0, "winrate": 0.5, "maxdd": 0.1}
 
     monkeypatch.setattr(wfv, "_dominates", lambda *args, **kwargs: True)
-    res = walk_forward_grid_search(df, grid, bt, train_window=4, test_window=2, step=2)
+    res = wfv.walk_forward_grid_search(df, grid, bt, train_window=4, test_window=2, step=2)
     assert (res[["tp", "sl"]] == 1).all().all()
 
 
 def test_prune_features_missing_columns():
+    wfv = load_wfv()
     df = pd.DataFrame({"a": [1], "c": [3]})
     imp = {"a": 0.005, "b": 0.001, "c": 0.5}
-    new_df, dropped = prune_features_by_importance(df, imp, threshold=0.01)
+    new_df, dropped = wfv.prune_features_by_importance(df, imp, threshold=0.01)
     assert list(new_df.columns) == ["c"]
     assert dropped == ["a"]


### PR DESCRIPTION
## Summary
- เขียนฟังก์ชัน `load_wfv` เพื่อโหลดโมดูลแบบไม่ผ่าน `src` และใช้ในทุกการทดสอบ
- เพิ่มไฟล์ `test_wfv_full.py` ครอบคลุมกรณี Optuna และ grid search เพิ่มเติม
- แก้ไข `test_wfv_utils_extra.py` และ `test_optuna_wfv.py` ให้ใช้ `load_wfv`
- อัปเดต CHANGELOG

## Testing
- `pytest -q tests/test_wfv_utils_extra.py tests/test_optuna_wfv.py tests/test_wfv_full.py`

------
https://chatgpt.com/codex/tasks/task_e_684312df1e008325a035c56f996124c8