### PR TITLE
[Patch v5.9.16] Fix tests import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### 2025-06-06
+- [Patch v5.9.16] Fix tests import path
+- New/Updated unit tests added for none (import fix)
+- QA: pytest tests/test_order_manager_more.py -q passed (7 tests)
+### 2025-06-06
 - [Patch v5.9.15] Add wfv unit tests
 - New/Updated unit tests added for tests.test_wfv_full
 - QA: pytest -q passed (11 tests)

--- a/tests/test_order_manager_more.py
+++ b/tests/test_order_manager_more.py
@@ -12,7 +12,7 @@ sys.path.insert(0, ROOT_DIR)
 
 import src.order_manager as om
 
-from tests.test_order_manager_module import _setup_strategy
+from test_order_manager_module import _setup_strategy
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- update CHANGELOG
- fix order manager import path for tests

## Testing
- `pytest tests/test_order_manager_more.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68431aa395ac8325a5034d5af632b635