### PR TITLE
[Patch v5.10.2] Document lazy imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### 2025-06-06
+- [Patch v5.10.2] Clarify lazy imports in profile_backtest
+- New/Updated unit tests added for none (doc comment)
+- QA: pytest -q failed (ImportError in tests)
+
+### 2025-06-06
 - [Patch v5.10.1] Refactor imports for pytest handling in profile_backtest
 - New/Updated unit tests added for tests.test_profile_backtest
 - QA: pytest -q passed (703 tests)

--- a/profile_backtest.py
+++ b/profile_backtest.py
@@ -52,6 +52,7 @@ def run_parallel_feature_engineering(list_of_fold_params, processes=4):
 
 def get_fund_profile(name: str | None) -> dict:
     """Return fund profile dict from config by name."""
+    # [Patch v5.10.2] Import config lazily for pytest compatibility
     from src.config import FUND_PROFILES, DEFAULT_FUND_NAME
     if not name:
         name = DEFAULT_FUND_NAME
@@ -132,6 +133,7 @@ def main_profile(
     )
 
     if train:
+        # [Patch v5.10.2] Delay import to avoid side effects when testing
         from src.training import real_train_func
         real_train_func(train_output)
 


### PR DESCRIPTION
## Summary
- add patch comments for lazy imports in profile_backtest
- update changelog

## Testing
- `pytest -q` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68432155a0d08325a4e15728e7340da3