### PR TITLE
Fix config import fallback

### DIFF
--- a/threshold_optimization.py
+++ b/threshold_optimization.py
@@ -3,8 +3,11 @@ import argparse
 import pandas as pd
 import logging
 
-try:  # [Patch v5.10.2] fallback when heavy config import fails
-    from src.config import logger, optuna
+try:  # [Patch v5.10.3] robust fallback when heavy config import fails
+    import importlib
+    _cfg = importlib.import_module("src.config")
+    logger = getattr(_cfg, "logger", logging.getLogger("threshold_optimization"))
+    optuna = getattr(_cfg, "optuna", None)
 except Exception:  # pragma: no cover - optional dependency
     logger = logging.getLogger("threshold_optimization")
     try:


### PR DESCRIPTION
## Summary
- make `threshold_optimization` handle partially-loaded `src.config` via `importlib`

## Testing
- `pytest tests/test_threshold_optimization.py tests/test_projectp_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684324f3b1288325ae4dbaee68f34148