### PR TITLE
[Patch v5.10.5] ปรับ config กัน Torch Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1212,3 +1212,7 @@ QA: pytest -q passed (219 tests)
 - [Patch v5.10.4] Update function registry line numbers
 - New/Updated unit tests added for tests/test_function_registry.py
 - QA: pytest tests/test_function_registry.py -q passed (46 tests)
+### 2025-06-06
+- [Patch v5.10.5] เพิ่มการจัดการ import torch และค่าเริ่มต้น FUND_PROFILES
+- New/Updated unit tests added for none (config fallback)
+- QA: pytest -q failed (import errors)


### PR DESCRIPTION
## Summary
- ปรับส่วนตรวจสอบ GPU ให้จับข้อผิดพลาด `import torch` หรือ `CUDA` ไม่พร้อมโดยไม่ทำให้โค้ดล้ม
- เพิ่มตัวแปร `DEFAULT_FUND_NAME` และ `FUND_PROFILES` แบบ fallback เพื่อให้ `profile_backtest.py` ใช้งานได้ตลอด
- อัปเดต CHANGELOG

## Testing
- `pytest tests/test_fund_profiles_import.py::test_fund_profiles_loaded_from_config -q` *(ล้มเหลวเนื่องจากข้อจำกัดสภาพแวดล้อม)*

------
https://chatgpt.com/codex/tasks/task_e_68433596b0a8832595687e2090cbbda7