### PR TITLE
Fix profile backtest imports

### DIFF
--- a/profile_backtest.py
+++ b/profile_backtest.py
@@ -12,6 +12,7 @@ import sys
 import os
 import time
 import datetime
+import importlib
 import tracemalloc
 import pandas as pd
 import logging

--- a/tests/test_optuna_wfv.py
+++ b/tests/test_optuna_wfv.py
@@ -18,6 +18,7 @@ def load_wfv():
 
 import optuna
 
+_real_config = importlib.import_module("src.config")
 config = types.SimpleNamespace(optuna=optuna)
 sys.modules["src.config"] = config
 
@@ -61,3 +62,7 @@ def test_optuna_walk_forward_per_fold_overlap_error():
     space = {'signal': (0.5, 1.0, 0.5)}
     with pytest.raises(AssertionError):
         wfv.optuna_walk_forward_per_fold(df, space, dummy_backtest, train_window=4, test_window=1, step=1, n_trials=1)
+
+
+def teardown_module(module):
+    sys.modules["src.config"] = _real_config


### PR DESCRIPTION
## Summary
- ensure `profile_backtest.get_fund_profile` imports `importlib`
- restore original `src.config` after optuna WFV tests

## Testing
- `python run_tests.py -q` *(fails: 3 failed, 729 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6843397176a08325b6236a220a009a8e