### PR TITLE
[Patch v5.8.13] QA fallback output files

### DIFF
--- a/ProjectP.py
+++ b/ProjectP.py
@@ -207,6 +207,23 @@ if __name__ == "__main__":
                 logging.getLogger().error(msg)
                 os.makedirs(output_dir, exist_ok=True)
                 open(fpath, "w", encoding="utf-8").close()
+
+        # [Patch v5.8.13] Ensure fallback QA output files always exist
+        fallback_files = [
+            "./output_default/features_main.json",
+            "./output_default/trade_log_BUY.csv",
+            "./output_default/trade_log_SELL.csv",
+            "./output_default/trade_log_NORMAL.csv",
+        ]
+
+        for f in fallback_files:
+            if not os.path.exists(f) or os.path.getsize(f) == 0:
+                if f.endswith('.json'):
+                    with open(f, 'w') as fout:
+                        json.dump({"status": "not_generated", "reason": "no output from sweep"}, fout)
+                elif f.endswith('.csv'):
+                    pd.DataFrame().to_csv(f, index=False)
+                logger.warning(f"[QA Fallback] Created missing file: {f}")
     except KeyboardInterrupt:
         print("\n(Stopped) การทำงานถูกยกเลิกโดยผู้ใช้.")
     except Exception as e:

--- a/tests/test_projectp_fallback.py
+++ b/tests/test_projectp_fallback.py
@@ -1,0 +1,30 @@
+import runpy
+import types
+import sys
+import os
+import json
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT_DIR)
+
+
+def test_fallback_files_created(monkeypatch, tmp_path):
+    """Script should generate dummy files when outputs are missing."""
+    out_dir = tmp_path / "output_default"
+    monkeypatch.chdir(tmp_path)
+    dummy_main = lambda: None
+    monkeypatch.setitem(sys.modules, "src.main", types.SimpleNamespace(main=dummy_main))
+    monkeypatch.setattr(sys, "argv", ["ProjectP.py"])
+    script_path = os.path.join(ROOT_DIR, "ProjectP.py")
+    runpy.run_path(script_path, run_name="__main__")
+    files = [
+        "features_main.json",
+        "trade_log_BUY.csv",
+        "trade_log_SELL.csv",
+        "trade_log_NORMAL.csv",
+    ]
+    for name in files:
+        assert (out_dir / name).exists()
+    with open(out_dir / "features_main.json", "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert data.get("status") == "not_generated"


### PR DESCRIPTION
## Summary
- create fallback QA output files with dummy JSON/CSV
- add unit test for fallback file creation

## Testing
- `python run_tests.py --fast`

------
https://chatgpt.com/codex/tasks/task_e_68439d2d9a948325bcc6593302e846fb