### PR TITLE
[Patch v5.8.13] Improve main pipeline test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### 2025-06-07
+- [Patch v5.8.13] เพิ่ม unit tests สำหรับ main.py ให้ครอบคลุมมากขึ้น
+- New/Updated unit tests added for tests/test_main_cli_extended.py
+- QA: pytest -q passed (819 tests)
+### 2025-06-07
 - [Patch v5.10.8] Add coverage for config module
 - New/Updated unit tests added for tests/test_config_extended.py
 - QA: pytest -q passed (792 tests)

--- a/tests/test_main_cli_extended.py
+++ b/tests/test_main_cli_extended.py
@@ -1,0 +1,135 @@
+import os
+import sys
+import subprocess
+import pandas as pd
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+import main as pipeline
+from src.utils.pipeline_config import PipelineConfig
+
+
+def test_parse_args_defaults():
+    args = pipeline.parse_args([])
+    assert args.mode == 'all'
+    assert args.output_file == 'backtest_profile.prof'
+    assert args.config.endswith('pipeline.yaml')
+
+
+def test_parse_args_custom():
+    args = pipeline.parse_args([
+        '--mode', 'backtest',
+        '--config', 'cfg.yaml',
+        '--log-level', 'debug'
+    ])
+    assert args.mode == 'backtest'
+    assert args.config == 'cfg.yaml'
+    assert args.log_level == 'debug'
+
+
+def test_run_preprocess_success():
+    called = {}
+    def fake_run(cmd, check):
+        called['cmd'] = cmd
+        called['check'] = check
+    pipeline.run_preprocess(PipelineConfig(), runner=fake_run)
+    assert 'ProjectP.py' in called['cmd'][1]
+    assert called['check']
+
+
+def test_run_preprocess_failure():
+    def fake_run(cmd, check):
+        raise subprocess.CalledProcessError(1, cmd)
+    with pytest.raises(pipeline.PipelineError):
+        pipeline.run_preprocess(PipelineConfig(), runner=fake_run)
+
+
+def test_run_sweep_success():
+    marker = {}
+    pipeline.run_sweep(PipelineConfig(), runner=lambda c, check: marker.setdefault('ok', True))
+    assert marker['ok']
+
+
+def test_run_threshold_failure():
+    def fail(cmd, check):
+        raise subprocess.CalledProcessError(1, cmd)
+    with pytest.raises(pipeline.PipelineError):
+        pipeline.run_threshold(PipelineConfig(), runner=fail)
+
+
+def test_run_backtest_selects_model_and_threshold(tmp_path):
+    cfg = PipelineConfig(model_dir=str(tmp_path), threshold_file='th.csv')
+    (tmp_path / 'model_a.joblib').write_text('x')
+    (tmp_path / 'model_b.joblib').write_text('x')
+    pd.DataFrame({'median': [0.4, 0.6]}).to_csv(tmp_path / 'th.csv', index=False)
+    captured = {}
+    def fake_pipe(f_df, p_df, model, thresh):
+        captured['model'] = model
+        captured['thresh'] = thresh
+    pipeline.run_backtest(cfg, pipeline_func=fake_pipe)
+    assert captured['model'].endswith('model_b.joblib')
+    assert captured['thresh'] == pytest.approx(0.5)
+
+
+def test_run_backtest_pipeline_error(tmp_path):
+    cfg = PipelineConfig(model_dir=str(tmp_path), threshold_file='th.csv')
+    def boom(*args):
+        raise RuntimeError('bad')
+    with pytest.raises(pipeline.PipelineError):
+        pipeline.run_backtest(cfg, pipeline_func=boom)
+
+
+def test_run_report_success(monkeypatch):
+    called = {}
+    import src.main as src_main
+    monkeypatch.setattr(src_main, 'run_pipeline_stage', lambda s: called.setdefault('stage', s))
+    pipeline.run_report(PipelineConfig())
+    assert called['stage'] == 'report'
+
+
+def test_run_report_failure(monkeypatch):
+    import src.main as src_main
+    monkeypatch.setattr(src_main, 'run_pipeline_stage', lambda s: (_ for _ in ()).throw(Exception('x')))
+    with pytest.raises(pipeline.PipelineError):
+        pipeline.run_report(PipelineConfig())
+
+
+def test_run_all_sequence(monkeypatch):
+    order = []
+    monkeypatch.setattr(pipeline, 'run_preprocess', lambda c: order.append('preprocess'))
+    monkeypatch.setattr(pipeline, 'run_sweep', lambda c: order.append('sweep'))
+    monkeypatch.setattr(pipeline, 'run_threshold', lambda c: order.append('threshold'))
+    monkeypatch.setattr(pipeline, 'run_backtest', lambda c: order.append('backtest'))
+    monkeypatch.setattr(pipeline, 'run_report', lambda c: order.append('report'))
+    pipeline.run_all(PipelineConfig())
+    assert order == ['preprocess', 'sweep', 'threshold', 'backtest', 'report']
+
+
+def test_main_handles_pipeline_error(monkeypatch):
+    monkeypatch.setattr(pipeline, 'run_backtest', lambda c: (_ for _ in ()).throw(pipeline.PipelineError('x')))
+    monkeypatch.setattr(pipeline, 'setup_logging', lambda level: None)
+    res = pipeline.main(['--mode', 'backtest'])
+    assert res == 1
+
+
+def test_main_handles_file_not_found(monkeypatch):
+    monkeypatch.setattr(pipeline, 'run_backtest', lambda c: (_ for _ in ()).throw(FileNotFoundError('x')))
+    monkeypatch.setattr(pipeline, 'setup_logging', lambda level: None)
+    res = pipeline.main(['--mode', 'backtest'])
+    assert res == 1
+
+
+def test_main_handles_value_error(monkeypatch):
+    monkeypatch.setattr(pipeline, 'run_backtest', lambda c: (_ for _ in ()).throw(ValueError('x')))
+    monkeypatch.setattr(pipeline, 'setup_logging', lambda level: None)
+    res = pipeline.main(['--mode', 'backtest'])
+    assert res == 1
+
+
+def test_main_success(monkeypatch):
+    monkeypatch.setattr(pipeline, 'run_preprocess', lambda c: None)
+    monkeypatch.setattr(pipeline, 'setup_logging', lambda level: None)
+    res = pipeline.main(['--mode', 'preprocess', '--log-level', 'info'])
+    assert res == 0


### PR DESCRIPTION
## Summary
- add extensive unit tests for `main.py` covering CLI argument parsing, stage execution, and error handling
- document QA run in CHANGELOG

## Testing
- `pytest -k test_main_cli_extended -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b0de948483259a6e1c1c5e7697ff