### PR TITLE
[Patch v6.0.3] เพิ่ม unit tests strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1274,3 +1274,8 @@ QA: pytest -q passed (219 tests)
 - QA: pytest -q passed (788 tests)
 
 
+
+### 2025-06-07
+- [Patch v6.0.3] เพิ่ม coverage สำหรับ strategy.orchestration
+- New/Updated unit tests added for tests/unit/test_strategy_orchestration_edge.py
+- QA: pytest -q passed (825 tests)

--- a/tests/unit/test_strategy_orchestration_edge.py
+++ b/tests/unit/test_strategy_orchestration_edge.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pandas as pd
+import numpy as np
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT_DIR)
+
+from strategy import strategy as strategy_module
+
+
+def test_apply_strategy_length_mismatch(monkeypatch):
+    df = pd.DataFrame({"Close": [1, 2, 3]})
+    monkeypatch.setattr(strategy_module, "generate_open_signals", lambda x: np.array([1, 0]))
+    monkeypatch.setattr(strategy_module, "generate_close_signals", lambda x: np.array([0, 1, 0]))
+    with pytest.raises(ValueError):
+        strategy_module.apply_strategy(df)
+
+
+def test_run_backtest_does_not_mutate():
+    df = pd.DataFrame({"Close": [1.0, 1.1, 1.2]})
+    original = df.copy()
+    result = strategy_module.run_backtest(df, 1000.0)
+    assert result == []
+    pd.testing.assert_frame_equal(df, original)


### PR DESCRIPTION
## Summary
- เพิ่มไฟล์ `test_strategy_orchestration_edge.py` เพื่อทดสอบ edge case ของ `apply_strategy` และ `run_backtest`
- ปรับปรุง CHANGELOG ให้บันทึกแพตช์ล่าสุด

## Testing
- `pytest -q tests/unit/test_strategy_orchestration_edge.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843b58bec748325ac959139a2f2b0e9