### PR TITLE
เพิ่ม coverage สำหรับ config.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1124,7 +1124,7 @@ QA: pytest -q passed (219 tests)
 - QA: pytest -q passed
 
 
-\n
+
 ### 2025-06-04
 - [Patch v5.6.4] Add dashboard module and alert when MDD exceeds 10%
 - New/Updated unit tests added for tests.test_dashboard
@@ -1285,3 +1285,7 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.1.0] เพิ่มชุดทดสอบ main.py ครอบคลุมมากขึ้น
 - New/Updated unit tests added for tests/test_main_cli_new.py
 - QA: pytest -q passed (829 tests)
+### 2025-06-07
+- [Patch v6.1.1] เพิ่ม coverage สำหรับ src.config SESSION_TIMES_UTC
+- New/Updated unit tests added for tests/test_config_session_times.py
+- QA: pytest -q passed (842 tests)

--- a/tests/test_config_session_times.py
+++ b/tests/test_config_session_times.py
@@ -1,0 +1,31 @@
+import importlib
+import os
+import sys
+import types
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(1, os.path.join(ROOT_DIR, 'src'))
+
+
+def _import_config(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'seaborn', types.ModuleType('seaborn'))
+    monkeypatch.setitem(sys.modules, 'requests', types.ModuleType('requests'))
+    monkeypatch.setitem(sys.modules, 'shap', types.ModuleType('shap'))
+    if 'src.config' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'src.config', raising=False)
+    return importlib.import_module('src.config')
+
+
+def test_session_times_valid(monkeypatch):
+    monkeypatch.setenv('SESSION_TIMES_UTC', '{"Asia": [1, 8], "London": [7, 16]}')
+    cfg = _import_config(monkeypatch)
+    assert cfg.SESSION_TIMES_UTC == {'Asia': [1, 8], 'London': [7, 16]}
+
+
+def test_session_times_invalid(monkeypatch, caplog):
+    monkeypatch.setenv('SESSION_TIMES_UTC', 'oops')
+    cfg = _import_config(monkeypatch)
+    assert cfg.SESSION_TIMES_UTC == {'Asia': (22, 8), 'London': (7, 16), 'NY': (13, 21)}
+    assert any('SESSION_TIMES_UTC env var invalid' in rec.message for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- เพิ่มชุดทดสอบใหม่ `test_config_session_times.py` เพื่อตรวจสอบการตั้งค่า `SESSION_TIMES_UTC`
- บันทึกการเปลี่ยนแปลงลงใน CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ba7661448325b820943ba26837c0