### PR TITLE
Add default CatBoost hyperparameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2025-06-08
+- [Patch v5.9.3] Add default CatBoost hyperparameters to src.config
+- New/Updated unit tests added for tests/test_config_defaults.py
+- QA: pytest -q passed
 
 ### 2025-06-07
 - [Patch v5.9.2] Support both best_param.json and best_params.json in CLI

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,11 @@ OMS_DEFAULT = True
 PAPER_MODE = False
 POST_TRADE_COOLDOWN_BARS = 2
 
+# [Patch v5.9.3] Default hyperparameters used in training
+LEARNING_RATE = 0.01
+DEPTH = 6
+L2_LEAF_REG = None
+
 # ==============================================================================
 # ป้องกันกรณีที่ pytest import แค่ SimpleNamespace เดิม (fallback) โดยตรวจสอบสภาพแวดล้อม
 # ==============================================================================
@@ -669,6 +674,10 @@ class DefaultConfig:
     DATA_FILE_PATH_M1: str = DEFAULT_CSV_PATH_M1
     DATA_FILE_PATH_M15: str = DEFAULT_CSV_PATH_M15
     DEFAULT_RISK_PER_TRADE: float = FUND_PROFILES.get(DEFAULT_FUND_NAME, {}).get("risk", 0.01)
+    # [Patch v5.9.3] Default hyperparameters for CatBoost training
+    LEARNING_RATE: float = 0.01
+    DEPTH: int = 6
+    L2_LEAF_REG: float | None = None
 logging.info(f"Multi-Fund Mode: {MULTI_FUND_MODE}")
 if MULTI_FUND_MODE:
     logging.info(f"Fund Profiles: {list(FUND_PROFILES.keys())}")

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -16,3 +16,7 @@ def test_default_parameters():
     assert cfg.OMS_DEFAULT is True
     assert cfg.PAPER_MODE is False
     assert cfg.POST_TRADE_COOLDOWN_BARS == 2
+    # [Patch v5.9.3] New hyperparameter defaults
+    assert cfg.LEARNING_RATE == pytest.approx(0.01, rel=1e-6)
+    assert cfg.DEPTH == 6
+    assert cfg.L2_LEAF_REG is None

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -3,11 +3,11 @@ import os
 import pytest
 
 FUNCTIONS_INFO = [
-    ("src/config.py", "log_library_version", 153),
-    ("src/config.py", "_ensure_ta_installed", 198),
-    ("src/config.py", "is_colab", 429),
-    ("src/config.py", "print_gpu_utilization", 526),
-    ("src/config.py", "show_system_status", 578),
+    ("src/config.py", "log_library_version", 162),
+    ("src/config.py", "_ensure_ta_installed", 207),
+    ("src/config.py", "is_colab", 438),
+    ("src/config.py", "print_gpu_utilization", 536),
+    ("src/config.py", "show_system_status", 588),
 
 
     ("src/data_loader.py", "inspect_file_exists", 906),


### PR DESCRIPTION
## Summary
- default CatBoost training parameters in `src.config`
- update `DefaultConfig` dataclass with new fields
- add assertions for these defaults in tests
- adjust expected line numbers in `test_function_registry`
- document patch in `CHANGELOG`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d27369a08325988506b6279ce9e5