### PR TITLE
[Patch v6.1.3] พัฒนา wfv_runner ให้รัน Walk-Forward จริง

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### 2025-06-09
+- [Patch v6.1.3] Implement sample walk-forward execution in wfv_runner
+- New/Updated unit tests added for tests/test_wfv_runner.py
+- QA: pytest -q passed
 - [Patch v5.9.5] เรียก qa_check_and_create_outputs ก่อนเริ่ม run_mode เพื่อลด error log ที่ไม่จำเป็น
 - New/Updated unit tests added for none (script patch)
 - QA: pytest -q passed

--- a/tests/test_wfv_runner.py
+++ b/tests/test_wfv_runner.py
@@ -5,12 +5,12 @@ import wfv_runner
 def test_run_walkforward_logs(caplog):
     caplog.set_level(logging.INFO)
     wfv_runner.run_walkforward()
-    assert any('[Patch] run_walkforward stub executed' in record.message for record in caplog.records)
+    assert any('walk-forward completed' in r.message for r in caplog.records)
 
 
-def test_run_walkforward_return_and_log_once(caplog):
+def test_run_walkforward_return_frame(caplog):
     caplog.set_level(logging.INFO)
     result = wfv_runner.run_walkforward()
-    assert result is None
-    msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
-    assert msgs.count('[Patch] run_walkforward stub executed') == 1
+    assert result.shape[0] == 5
+    assert 'failed' in result.columns
+    assert any('walk-forward completed' in r.message for r in caplog.records)

--- a/wfv_runner.py
+++ b/wfv_runner.py
@@ -1,6 +1,22 @@
 import logging
+from typing import Dict
+
+import pandas as pd
+
+from src.wfv_monitor import walk_forward_validate
 
 
-def run_walkforward() -> None:
-    """Placeholder walk-forward run function."""
-    logging.info("[Patch] run_walkforward stub executed")
+def _simple_backtest(train: pd.DataFrame, test: pd.DataFrame) -> Dict[str, float]:
+    """[Patch] Minimal backtest for walk-forward example."""
+    pnl = float(test.Close.iloc[-1] - train.Close.iloc[0])
+    return {"pnl": pnl, "winrate": 0.6, "maxdd": 0.05, "auc": 0.7}
+
+
+def run_walkforward() -> pd.DataFrame:
+    """Run a sample walk-forward validation using :mod:`wfv_monitor`."""
+    logging.info("[Patch] Starting sample walk-forward")
+    df = pd.DataFrame({"Close": range(50)})
+    kpi = {"profit": 0.0, "winrate": 0.5, "maxdd": 0.1, "auc": 0.6}
+    result = walk_forward_validate(df, _simple_backtest, kpi, n_splits=5)
+    logging.info("[Patch] walk-forward completed")
+    return result


### PR DESCRIPTION
## Summary
- ปรับ `wfv_runner.run_walkforward` ให้ใช้ `wfv_monitor.walk_forward_validate`
- เขียนตัวอย่าง backtest แบบง่ายพร้อม KPI
- ปรับชุดทดสอบ `tests/test_wfv_runner.py` ให้ตรวจสอบผลลัพธ์ DataFrame
- บันทึกการเปลี่ยนแปลงใน CHANGELOG

## Testing
- `python3 run_tests.py --fast`

------
https://chatgpt.com/codex/tasks/task_e_684639aa2d58832596ec7442bfcffbdd