### PR TITLE
[Patch v6.1.4] เพิ่ม walk_forward_loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### 2025-06-09
+- [Patch v6.1.4] เพิ่ม walk_forward_loop และบันทึกผลเป็น CSV
+- New/Updated unit tests added for tests/test_wfv_monitor.py, tests/test_wfv_runner.py
+- QA: pytest -q passed (859 tests)
 - [Patch v6.1.3] Implement sample walk-forward execution in wfv_runner
 - New/Updated unit tests added for tests/test_wfv_runner.py
 - QA: pytest -q passed

--- a/tests/test_wfv_runner.py
+++ b/tests/test_wfv_runner.py
@@ -1,4 +1,5 @@
 import logging
+import pandas as pd
 import wfv_runner
 
 
@@ -14,3 +15,11 @@ def test_run_walkforward_return_frame(caplog):
     assert result.shape[0] == 5
     assert 'failed' in result.columns
     assert any('walk-forward completed' in r.message for r in caplog.records)
+
+
+def test_run_walkforward_output_csv(tmp_path):
+    path = tmp_path / 'out.csv'
+    res = wfv_runner.run_walkforward(output_path=str(path))
+    assert path.exists()
+    df = pd.read_csv(path)
+    assert len(df) == len(res)

--- a/wfv_runner.py
+++ b/wfv_runner.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 import pandas as pd
 
-from src.wfv_monitor import walk_forward_validate
+from src.wfv_monitor import walk_forward_loop
 
 
 def _simple_backtest(train: pd.DataFrame, test: pd.DataFrame) -> Dict[str, float]:
@@ -12,11 +12,19 @@ def _simple_backtest(train: pd.DataFrame, test: pd.DataFrame) -> Dict[str, float
     return {"pnl": pnl, "winrate": 0.6, "maxdd": 0.05, "auc": 0.7}
 
 
-def run_walkforward() -> pd.DataFrame:
-    """Run a sample walk-forward validation using :mod:`wfv_monitor`."""
+def run_walkforward(output_path: str | None = None) -> pd.DataFrame:
+    """Run a sample continuous walk-forward validation."""
     logging.info("[Patch] Starting sample walk-forward")
-    df = pd.DataFrame({"Close": range(50)})
+    df = pd.DataFrame({"Close": range(20)})
     kpi = {"profit": 0.0, "winrate": 0.5, "maxdd": 0.1, "auc": 0.6}
-    result = walk_forward_validate(df, _simple_backtest, kpi, n_splits=5)
+    result = walk_forward_loop(
+        df,
+        _simple_backtest,
+        kpi,
+        train_window=4,
+        test_window=2,
+        step=3,
+        output_path=output_path,
+    )
     logging.info("[Patch] walk-forward completed")
     return result


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `walk_forward_loop` เพื่อรัน Walk-Forward แบบต่อเนื่องและบันทึกผลต่อรอบ
- ปรับ `wfv_runner.run_walkforward` ให้ใช้ฟังก์ชันใหม่และรองรับการส่งออก CSV
- เพิ่มชุดทดสอบสำหรับ `walk_forward_loop` และอัปเดตการทดสอบ `wfv_runner`
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846859efd14832589ca37012751c233