### PR TITLE
Improve hyperparameter sweep & drift summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for tests/test_evaluation_drift_summary.py, tests/test_log_analysis_report.py, tests/test_projectp_sweep_defaults.py
 - QA: pytest -q passed
 
+### 2025-06-09
+- [Patch v6.2.1] ปรับปรุง hyperparameter sweep และฟังก์ชัน drift summary
+- New/Updated unit tests added for tests/test_hyperparameter_sweep_cli.py, tests/test_wfv_monitor.py
+- QA: pytest -q passed
+
 ### 2025-06-13
 - [Patch v6.1.8] เพิ่มฟังก์ชัน monitor_drift และ plot_expectancy_by_period
 - New/Updated unit tests added for tests/test_wfv_monitor.py, tests/test_log_analysis_extra.py, tests/test_projectp_sweep_defaults.py

--- a/src/wfv_monitor.py
+++ b/src/wfv_monitor.py
@@ -150,3 +150,20 @@ def monitor_drift(
         features = sorted(res.loc[res["drift"], "feature"].unique())
         logger.warning("Data drift detected for features: %s", features)
     return res
+
+
+# [Patch v6.2.1] Daily/weekly drift monitoring summary
+def monitor_drift_summary(
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    threshold: float | None = None,
+) -> pd.DataFrame:
+    """Calculate daily and weekly drift summary and log warnings."""
+
+    from src.evaluation import calculate_drift_summary
+
+    res = calculate_drift_summary(train_df, test_df, threshold=threshold)
+    if not res.empty and res["drift"].any():
+        feats = sorted(res.loc[res["drift"], "feature"].unique())
+        logger.warning("Data drift summary detected for features: %s", feats)
+    return res

--- a/tests/test_hyperparameter_sweep_cli.py
+++ b/tests/test_hyperparameter_sweep_cli.py
@@ -89,6 +89,8 @@ def test_parse_args_defaults():
     args = hs.parse_args([])
     assert args.trade_log_path == hs.DEFAULT_TRADE_LOG
     assert args.output_dir == hs.DEFAULT_SWEEP_DIR
+    assert args.param_subsample == '0.8,1.0'
+    assert args.param_colsample_bylevel == '0.8,1.0'
 
 
 def test_run_sweep_default_output_dir(tmp_path, monkeypatch):
@@ -233,5 +235,14 @@ def test_cli_entrypoint_runs_main(tmp_path, monkeypatch):
         warnings.simplefilter('ignore', RuntimeWarning)
         runpy.run_module('tuning.hyperparameter_sweep', run_name='__main__')
     assert (tmp_path / 'best_param.json').exists()
+
+
+def test_parse_args_custom_params():
+    args = hs.parse_args([
+        '--param_subsample', '0.7,1.0',
+        '--param_colsample_bylevel', '0.6,0.9',
+    ])
+    assert args.param_subsample == '0.7,1.0'
+    assert args.param_colsample_bylevel == '0.6,0.9'
 
 

--- a/tests/test_wfv_monitor.py
+++ b/tests/test_wfv_monitor.py
@@ -105,3 +105,13 @@ def test_monitor_drift_warning(caplog):
         res = wfv_monitor.monitor_drift(train_df, test_df, threshold=0.0)
     assert not res.empty
     assert res['drift'].any()
+
+
+def test_monitor_drift_summary_warning(caplog):
+    idx = pd.date_range('2024-01-01', periods=3, freq='D')
+    train_df = pd.DataFrame({'feat': [1.0, 2.0, 3.0]}, index=idx)
+    test_df = pd.DataFrame({'feat': [10.0, 11.0, 12.0]}, index=idx)
+    with caplog.at_level('WARNING', logger='src.wfv_monitor'):
+        res = wfv_monitor.monitor_drift_summary(train_df, test_df, threshold=0.0)
+    assert not res.empty
+    assert res['drift'].any()

--- a/tuning/hyperparameter_sweep.py
+++ b/tuning/hyperparameter_sweep.py
@@ -224,6 +224,8 @@ def parse_args(args=None) -> argparse.Namespace:
     parser.add_argument('--param_learning_rate', default='0.01,0.05')
     parser.add_argument('--param_depth', default='6,8')
     parser.add_argument('--param_l2_leaf_reg', default='1,3,5')
+    parser.add_argument('--param_subsample', default='0.8,1.0')  # [Patch v6.2.1] new CLI option
+    parser.add_argument('--param_colsample_bylevel', default='0.8,1.0')  # [Patch v6.2.1] new CLI option
     parser.add_argument(
         '--trade_log_path', '--trade-log',
         dest='trade_log_path',


### PR DESCRIPTION
## Summary
- add CLI options for `subsample` and `colsample_bylevel`
- expose new `monitor_drift_summary` helper
- test CLI defaults and custom params
- test drift summary warnings
- update changelog

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6846a4d687ac8325825672fe77aaa04d