### PR TITLE
[Patch v6.2.1] Add DATA_DIR defaults and hyperparam placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for tests/test_evaluation_drift_summary.py, tests/test_log_analysis_report.py, tests/test_projectp_sweep_defaults.py
 - QA: pytest -q passed
 
+### 2025-06-14
+- [Patch v6.2.1] สร้าง DATA_DIR และกำหนด SYMBOL/TIMEFRAME พร้อมค่า hyperparameter เริ่มต้น
+- New/Updated unit tests added for tests/test_config_defaults.py, tests/test_config_data_dir.py
+- QA: pytest -q passed (874 tests)
+
 ### 2025-06-13
 - [Patch v6.1.8] เพิ่มฟังก์ชัน monitor_drift และ plot_expectancy_by_period
 - New/Updated unit tests added for tests/test_wfv_monitor.py, tests/test_log_analysis_extra.py, tests/test_projectp_sweep_defaults.py

--- a/src/config.py
+++ b/src/config.py
@@ -64,9 +64,30 @@ VERSION_FILE = os.path.join(os.path.dirname(__file__), '..', 'VERSION')
 with open(VERSION_FILE, 'r', encoding='utf-8') as vf:
     __version__ = vf.read().strip()
 from pathlib import Path
+import pathlib
 # [Patch v5.9.1] Unified output directory constant
 OUTPUT_DIR = Path(__file__).parent.parent / "output_default"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# [Patch v6.2.1] Define default data directory and naming for walk-forward data
+BASE_DIR = pathlib.Path(__file__).parent
+DATA_DIR = BASE_DIR.parent / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+# Defaults for data file naming
+SYMBOL = globals().get("SYMBOL", "XAUUSD")
+TIMEFRAME = globals().get("TIMEFRAME", "M1")
+
+# [Patch v6.2.1] Default hyperparameters to prevent missing attribute warnings
+for _attr in [
+    "subsample",
+    "colsample_bylevel",
+    "bagging_temperature",
+    "random_strength",
+    "seed",
+]:
+    if _attr not in globals():
+        globals()[_attr] = None
 from sklearn.model_selection import TimeSeriesSplit, train_test_split
 from sklearn.preprocessing import StandardScaler, OrdinalEncoder # Added OrdinalEncoder back as it might be used by some logic
 from sklearn.metrics import (

--- a/tests/test_config_data_dir.py
+++ b/tests/test_config_data_dir.py
@@ -1,0 +1,27 @@
+import importlib
+import shutil
+import sys
+
+
+def test_data_dir_and_hyperparams(monkeypatch):
+    monkeypatch.delenv('SYMBOL', raising=False)
+    monkeypatch.delenv('TIMEFRAME', raising=False)
+    if 'src.config' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'src.config', raising=False)
+    cfg = importlib.import_module('src.config')
+    try:
+        assert cfg.DATA_DIR.is_dir()
+        assert cfg.SYMBOL == 'XAUUSD'
+        assert cfg.TIMEFRAME == 'M1'
+        for attr in [
+            'subsample',
+            'colsample_bylevel',
+            'bagging_temperature',
+            'random_strength',
+            'seed',
+        ]:
+            assert hasattr(cfg, attr)
+            assert getattr(cfg, attr) is None
+    finally:
+        shutil.rmtree(cfg.DATA_DIR, ignore_errors=True)
+

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -20,3 +20,15 @@ def test_default_parameters():
     assert cfg.LEARNING_RATE == pytest.approx(0.01, rel=1e-6)
     assert cfg.DEPTH == 6
     assert cfg.L2_LEAF_REG is None
+    # [Patch v6.2.1] New placeholders and defaults
+    assert cfg.SYMBOL == "XAUUSD"
+    assert cfg.TIMEFRAME == "M1"
+    for attr in [
+        "subsample",
+        "colsample_bylevel",
+        "bagging_temperature",
+        "random_strength",
+        "seed",
+    ]:
+        assert hasattr(cfg, attr)
+        assert getattr(cfg, attr) is None

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -3,11 +3,11 @@ import os
 import pytest
 
 FUNCTIONS_INFO = [
-    ("src/config.py", "log_library_version", 162),
-    ("src/config.py", "_ensure_ta_installed", 207),
-    ("src/config.py", "is_colab", 438),
-    ("src/config.py", "print_gpu_utilization", 536),
-    ("src/config.py", "show_system_status", 588),
+    ("src/config.py", "log_library_version", 183),
+    ("src/config.py", "_ensure_ta_installed", 228),
+    ("src/config.py", "is_colab", 459),
+    ("src/config.py", "print_gpu_utilization", 557),
+    ("src/config.py", "show_system_status", 609),
 
 
     ("src/data_loader.py", "inspect_file_exists", 906),


### PR DESCRIPTION
## Summary
- create `data` directory and default SYMBOL/TIMEFRAME
- add placeholder hyperparameter attributes
- update tests and CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a4f5c054832591c846759dc21b0e