### PR TITLE
Fix getcwd and MKL fatal error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-06-15
+- [Patch v6.2.3] Handle getcwd and MKL errors
+- New/Updated unit tests added for tests/test_projectp_getcwd.py, tests/test_config_mkl_error.py
+- QA: pytest -q passed (2 tests)
+
 ### 2025-06-14
 - [Patch v6.2.2] เพิ่ม monitor_auc_drop เพื่อตรวจจับ AUC ต่ำกว่าค่ากำหนด
 - New/Updated unit tests added for tests/test_wfv_monitor.py

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -14,6 +14,12 @@ import os
 import argparse
 import subprocess
 import json
+
+# [Patch v6.2.3] Auto-fallback to project root if current working dir is invalid
+try:
+    os.getcwd()
+except Exception:
+    os.chdir(Path(__file__).resolve().parent)
 import pandas as pd
 from typing import Dict, List
 import main as pipeline

--- a/src/config.py
+++ b/src/config.py
@@ -548,10 +548,16 @@ try:
         logging.debug(f"CUDA check error: {e_cuda}")
         USE_GPU_ACCELERATION = False
 except Exception as e_torch_import:
-    # [Patch v5.10.5] ป้องกันโค้ดล้มเมื่อไม่สามารถนำเข้า torch ได้
-    logging.warning(
-        "   (Warning) ไม่พบ 'torch' หรือไม่สามารถโหลดได้ -- ปิด GPU Acceleration."
-    )
+    # [Patch v6.2.3] Handle Intel MKL errors during PyTorch import
+    msg = str(e_torch_import)
+    if "mkl" in msg.lower():
+        logging.warning(
+            "   (Warning) Intel MKL error detected -- ปิด GPU Acceleration."
+        )
+    else:
+        logging.warning(
+            "   (Warning) ไม่พบ 'torch' หรือไม่สามารถโหลดได้ -- ปิด GPU Acceleration."
+        )
     logging.debug(f"PyTorch import error: {e_torch_import}")
     USE_GPU_ACCELERATION = False
 logging.info(f"   สถานะการเร่งความเร็วด้วย GPU: {USE_GPU_ACCELERATION}")

--- a/tests/test_config_mkl_error.py
+++ b/tests/test_config_mkl_error.py
@@ -1,0 +1,32 @@
+import builtins
+import importlib
+import logging
+import os
+import sys
+import types
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT_DIR)
+
+
+def _import_config(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'seaborn', types.ModuleType('seaborn'))
+    monkeypatch.setitem(sys.modules, 'requests', types.ModuleType('requests'))
+    if 'src.config' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'src.config', raising=False)
+    return importlib.import_module('src.config')
+
+
+def test_mkl_error_fallback(monkeypatch, caplog):
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'torch':
+            raise RuntimeError('Intel MKL FATAL ERROR: cannot load mkl_intel_thread.dll')
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    with caplog.at_level(logging.WARNING):
+        cfg = _import_config(monkeypatch)
+    assert cfg.USE_GPU_ACCELERATION is False
+    assert any('Intel MKL error' in m for m in caplog.messages)

--- a/tests/test_projectp_getcwd.py
+++ b/tests/test_projectp_getcwd.py
@@ -1,0 +1,22 @@
+import importlib
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT_DIR)
+
+
+def test_projectp_getcwd_fallback(monkeypatch):
+    def bad_getcwd():
+        raise OSError("bad cwd")
+
+    recorded = {}
+
+    def fake_chdir(path):
+        recorded['path'] = path
+
+    monkeypatch.setattr(os, 'getcwd', bad_getcwd)
+    monkeypatch.setattr(os, 'chdir', fake_chdir)
+    monkeypatch.delitem(sys.modules, 'ProjectP', raising=False)
+    importlib.import_module('ProjectP')
+    assert str(recorded['path']) == ROOT_DIR


### PR DESCRIPTION
## Summary
- auto-change CWD to project root if `os.getcwd()` fails
- detect Intel MKL errors during torch import and disable GPU
- add tests for new fallback logic

## Testing
- `pytest -q tests/test_projectp_getcwd.py tests/test_config_mkl_error.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f4b306d48325a063df7e1088c178