### PR TITLE
[Patch v6.2.4] fallback when CUDA unavailable

### DIFF
--- a/src/adaptive.py
+++ b/src/adaptive.py
@@ -3,6 +3,24 @@ import logging
 from pathlib import Path
 from typing import Optional, Tuple
 
+import warnings
+# [Patch] Add CPU-only fallback for missing CUDA libraries
+try:
+    import torch
+except OSError as e:  # pragma: no cover - env-specific
+    warnings.warn(
+        f"CUDA libraries not found ({e}), defaulting to CPU-only mode"
+    )
+
+    class _DummyCuda:
+        def is_available(self):
+            return False
+
+    class _DummyTorch:
+        cuda = _DummyCuda()
+
+    torch = _DummyTorch()
+
 import pandas as pd
 from src import features
 


### PR DESCRIPTION
## Summary
- add a CPU-only fallback when `torch` fails to import

## Testing
- no tests run per user request

------
https://chatgpt.com/codex/tasks/task_e_68470179f15083258b09a46512842087