### PR TITLE
Update cache test cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-06-18
+- [Patch v6.2.6] Update test_data_cache to use tmp_path and safe removal logic
+- New/Updated unit tests added for tests/test_data_cache.py
+- QA: Skipped tests per user request
+
 ### 2025-06-16
 - [Patch v6.2.4] Add CPU-only fallback for missing CUDA libraries and Colab test script
 - QA: pytest -q passed

--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -1,4 +1,3 @@
-import os
 import pandas as pd
 from src.data_loader import load_data_cached
 
@@ -19,8 +18,34 @@ def test_load_data_cached_parquet(tmp_path):
     cache_file = csv_path.with_suffix('.parquet')
     # บางสภาพแวดล้อมอาจไม่รองรับ pyarrow หรือ fastparquet
     if cache_file.exists():
-        os.remove(csv_path)
+        # [Patch] Guard cache file removal and use tmp_path for isolation
+        import logging
+        from pathlib import Path
+
+        temp_csv = Path(tmp_path) / "cache.csv"
+        if temp_csv.exists():
+            temp_csv.unlink()
+        else:
+            logger = logging.getLogger(__name__)
+            logger.warning(f"Cache file {temp_csv} not found, skipping removal")
+
         df_cached = load_data_cached(str(csv_path), 'M1', cache_format='parquet')
         assert not df_cached.empty
     else:
         assert not df_loaded.empty
+
+
+def test_data_cache_flush(tmp_path):
+    """Ensure temporary cache files are safely removed."""
+    import logging
+    from pathlib import Path
+
+    temp_csv = Path(tmp_path) / "cache.csv"
+    temp_csv.write_text("x")
+    if temp_csv.exists():
+        temp_csv.unlink()
+    else:
+        logger = logging.getLogger(__name__)
+        logger.warning(f"Cache file {temp_csv} not found, skipping removal")
+
+    assert not temp_csv.exists()


### PR DESCRIPTION
## Summary
- improve safe removal logic for cached files in tests
- cover temporary cleanup with new `test_data_cache_flush`
- document the patch in CHANGELOG

## Testing
- Skipped tests per user request

------
https://chatgpt.com/codex/tasks/task_e_68470464aed083259edaf3cfed9c7443