### PR TITLE
Fix lazy imports & circular logging

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,41 +1,44 @@
-"""Top-level package for project modules."""
+"""Top-level package for project modules with lazy imports.
 
-from src.adaptive import (
-    adaptive_sl_tp,
-    adaptive_risk,
-    log_best_params,
-    calculate_atr,
-    atr_position_size,
-)
-from src.money_management import (
-    atr_sl_tp,
-    update_be_trailing,
-    adaptive_position_size,
-    portfolio_hard_stop,
-)
-from src.evaluation import (
-    evaluate_meta_classifier,
-    walk_forward_yearly_validation,
-    detect_overfit_wfv,
-)
-from src.wfv import walk_forward_grid_search, prune_features_by_importance
-from src.param_stability import save_fold_params, analyze_param_stability
+This module exposes frequently used submodules while avoiding heavy
+imports during package initialization. Submodules are imported on first
+access via ``__getattr__`` to keep test environments lightweight.
+"""
 
-__all__ = [
-    "adaptive_sl_tp",
-    "adaptive_risk",
-    "log_best_params",
-    "calculate_atr",
-    "atr_position_size",
-    "atr_sl_tp",
-    "update_be_trailing",
-    "adaptive_position_size",
-    "portfolio_hard_stop",
-    "evaluate_meta_classifier",
-    "walk_forward_yearly_validation",
-    "detect_overfit_wfv",
-    "walk_forward_grid_search",
-    "prune_features_by_importance",
-    "save_fold_params",
-    "analyze_param_stability",
+from __future__ import annotations
+
+import importlib
+import sys
+
+# List of submodules that can be lazily loaded via ``from src import <module>``.
+_SUBMODULES = [
+    "adaptive",
+    "money_management",
+    "evaluation",
+    "wfv",
+    "param_stability",
+    "config",
+    "data_loader",
+    "feature_analysis",
+    "features",
+    "main",
+    "order_manager",
+    "realtime_dashboard",
+    "signal_classifier",
+    "strategy",
+    "training",
+    "wfv_monitor",
+    "log_analysis",
+    "qa_tools",
 ]
+
+__all__ = list(_SUBMODULES)
+
+
+def __getattr__(name: str):
+    """Dynamically import submodules on first access."""
+    if name in _SUBMODULES:
+        module = importlib.import_module(f"{__name__}.{name}")
+        setattr(sys.modules[__name__], name, module)
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/adaptive.py
+++ b/src/adaptive.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 import warnings
-# [Patch v6.2.5] CPU-only fallback for missing CUDA libraries
+# [Patch v6.2.5] CPU-only fallback for missing CUDA libraries and missing torch
 try:
     import torch
-except OSError as e:
-    warnings.warn(f"CUDA libraries not found ({e}), defaulting to CPU-only mode")
+except Exception as e:  # ModuleNotFoundError or OSError
+    warnings.warn(f"torch unavailable ({e}), defaulting to CPU-only mode")
 
     class _DummyCuda:
         def is_available(self):

--- a/src/config.py
+++ b/src/config.py
@@ -68,10 +68,11 @@ with open(VERSION_FILE, 'r', encoding='utf-8') as vf:
     __version__ = vf.read().strip()
 from pathlib import Path
 import pathlib
-# [Patch v6.3.1] Register module as 'config' for reload compatibility
-if __spec__:
-    __spec__.name = 'config'
-sys.modules.setdefault('config', sys.modules[__name__])
+# [Patch v6.3.1] Register module as 'config' for reload compatibility (disabled)
+# -- placeholder to preserve line numbers --
+# -- placeholder line 2 --
+# -- placeholder line 3 --
+# -- placeholder line 4 --
 # [Patch v5.9.1] Unified output directory constant
 OUTPUT_DIR = Path(__file__).parent.parent / "output_default"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/utils/sessions.py
+++ b/src/utils/sessions.py
@@ -1,9 +1,9 @@
 """Session tagging utilities shared across modules."""
 
-try:
-    from src.config import logger
-except Exception:  # pragma: no cover - fallback when config import fails
-    import logging as logger
+import logging
+
+# Local logger avoids circular import during ``src.config`` initialization.
+logger = logging.getLogger(__name__)
 import pandas as pd
 
 # [Patch v5.5.5] Define module-level default to avoid NameError

--- a/src/utils/trade_logger.py
+++ b/src/utils/trade_logger.py
@@ -1,10 +1,9 @@
 """Helper utilities for exporting trade logs with QA markers."""
 
-try:
-    from src.config import logger
-except Exception:  # pragma: no cover - fallback only during missing config
-    import logging
-    logger = logging.getLogger(__name__)
+import logging
+
+# Logger is defined locally to avoid circular import with ``src.config``.
+logger = logging.getLogger(__name__)
 
 import os
 from dataclasses import dataclass, asdict

--- a/src/utils/trade_splitter.py
+++ b/src/utils/trade_splitter.py
@@ -1,8 +1,8 @@
-try:
-    from src.config import logger
-except Exception:
-    import logging
-    logger = logging.getLogger(__name__)
+import logging
+
+# Use a local logger to prevent circular import with ``src.config`` during test
+# collection.
+logger = logging.getLogger(__name__)
 
 import os
 import pandas as pd


### PR DESCRIPTION
## Summary
- implement lazy submodule loading in `src/__init__`
- guard optional torch import in `src/adaptive`
- avoid circular config imports for utility modules
- remove package aliasing in `src.config`

## Testing
- `pytest -q tests/test_rsi_drift_threshold.py::test_rsi_drift_override_threshold_default -q`
- `pytest -q tests/test_config_class.py -q`
- `pytest -q tests/test_env_utils.py -q`
- `pytest -q tests/test_shap_install.py -q`
- `pytest -q tests/test_ta_install.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config.config'; 'config' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_684711a774288325880e30a66946cbe7