### PR TITLE
Fix test registry line numbers

### DIFF
--- a/tests/test_config_data_dir.py
+++ b/tests/test_config_data_dir.py
@@ -14,6 +14,7 @@ def test_config_data_dir(tmp_path, monkeypatch):
     monkeypatch.delenv('TIMEFRAME', raising=False)
     if 'src.config' in sys.modules:
         monkeypatch.delitem(sys.modules, 'src.config', raising=False)
+    sys.modules['src.config'] = cfg
     importlib.reload(cfg)
 
     assert cfg.DATA_DIR.is_dir()

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -3,11 +3,11 @@ import os
 import pytest
 
 FUNCTIONS_INFO = [
-    ("src/config.py", "log_library_version", 183),
-    ("src/config.py", "_ensure_ta_installed", 228),
-    ("src/config.py", "is_colab", 459),
-    ("src/config.py", "print_gpu_utilization", 557),
-    ("src/config.py", "show_system_status", 609),
+    ("src/config.py", "log_library_version", 196),
+    ("src/config.py", "_ensure_ta_installed", 241),
+    ("src/config.py", "is_colab", 472),
+    ("src/config.py", "print_gpu_utilization", 572),
+    ("src/config.py", "show_system_status", 624),
 
 
     ("src/data_loader.py", "inspect_file_exists", 906),
@@ -40,13 +40,13 @@ FUNCTIONS_INFO = [
 
 # [Patch v5.5.3] Updated expected line numbers
 
-    ("src/main.py", "parse_arguments", 1890),
-    ("src/main.py", "setup_output_directory", 1895),
-    ("src/main.py", "load_features_from_file", 1900),
-    ("src/main.py", "drop_nan_rows", 1905),
-    ("src/main.py", "convert_to_float32", 1910),
-    ("src/main.py", "run_initial_backtest", 1915),
-    ("src/main.py", "save_final_data", 1920),
+    ("src/main.py", "parse_arguments", 1903),
+    ("src/main.py", "setup_output_directory", 1908),
+    ("src/main.py", "load_features_from_file", 1913),
+    ("src/main.py", "drop_nan_rows", 1918),
+    ("src/main.py", "convert_to_float32", 1923),
+    ("src/main.py", "run_initial_backtest", 1928),
+    ("src/main.py", "save_final_data", 1933),
 
 
 
@@ -54,40 +54,40 @@ FUNCTIONS_INFO = [
 
 
 
-    ("src/main.py", "parse_arguments", 1890),
-    ("src/main.py", "setup_output_directory", 1895),
-    ("src/main.py", "load_features_from_file", 1900),
-    ("src/main.py", "drop_nan_rows", 1905),
-    ("src/main.py", "convert_to_float32", 1910),
-    ("src/main.py", "run_initial_backtest", 1915),
-    ("src/main.py", "save_final_data", 1920),
+    ("src/main.py", "parse_arguments", 1903),
+    ("src/main.py", "setup_output_directory", 1908),
+    ("src/main.py", "load_features_from_file", 1913),
+    ("src/main.py", "drop_nan_rows", 1918),
+    ("src/main.py", "convert_to_float32", 1923),
+    ("src/main.py", "run_initial_backtest", 1928),
+    ("src/main.py", "save_final_data", 1933),
 
 
 
 
 
 
-    ("src/strategy.py", "run_backtest_simulation_v34", 1948),
+    ("src/strategy.py", "run_backtest_simulation_v34", 1951),
 
-    ("src/strategy.py", "initialize_time_series_split", 4621),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4624),
-    ("src/strategy.py", "apply_kill_switch", 4627),
-    ("src/strategy.py", "log_trade", 4630),
+    ("src/strategy.py", "initialize_time_series_split", 4622),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4625),
+    ("src/strategy.py", "apply_kill_switch", 4628),
+    ("src/strategy.py", "log_trade", 4631),
 
-    ("src/strategy.py", "calculate_metrics", 3249),
+    ("src/strategy.py", "calculate_metrics", 3250),
 
-    ("src/strategy.py", "aggregate_fold_results", 4633),
-
-
-    ("src/strategy.py", "aggregate_fold_results", 4633),
+    ("src/strategy.py", "aggregate_fold_results", 4634),
 
 
+    ("src/strategy.py", "aggregate_fold_results", 4634),
 
 
 
 
 
-    ("ProjectP.py", "custom_helper_function", 51),
+
+
+    ("ProjectP.py", "custom_helper_function", 67),
 ]
 
 

--- a/tests/test_loader_main_functions.py
+++ b/tests/test_loader_main_functions.py
@@ -91,6 +91,7 @@ def test_clean_test_file_guard(tmp_path, caplog, monkeypatch):
     monkeypatch.setenv('DATA_DIR', str(tmp_path))
     import importlib
     import src.config as config
+    sys.modules['src.config'] = config
     importlib.reload(config)
     import src.data_loader as dl_reload
     importlib.reload(dl_reload)

--- a/tests/test_sessions_utils.py
+++ b/tests/test_sessions_utils.py
@@ -61,6 +61,8 @@ def test_get_session_tag_end_boundary_asia():
 
 
 def test_get_session_tag_warn_once(caplog):
+    from src.utils.sessions import _WARNED_OUT_OF_RANGE
+    _WARNED_OUT_OF_RANGE.clear()
     ts1 = pd.Timestamp('2024-01-01 03:00', tz='UTC')
     ts2 = ts1 + pd.Timedelta(minutes=15)
     custom = {'Test': (0, 1)}
@@ -76,6 +78,8 @@ def test_get_session_tag_missing_global(monkeypatch, caplog):
     # ลบตัวแปร SESSION_TIMES_UTC ชั่วคราวเพื่อทดสอบ path fallback
     backup = utils.sessions.SESSION_TIMES_UTC
     monkeypatch.delattr(utils.sessions, 'SESSION_TIMES_UTC', raising=False)
+    from src.utils import sessions
+    sessions._WARNED_OUT_OF_RANGE.clear()
     ts = pd.Timestamp('2024-01-01 01:00', tz='UTC')
     with caplog.at_level('WARNING'):
         tag = get_session_tag(ts)

--- a/tests/test_warning_skip_extra.py
+++ b/tests/test_warning_skip_extra.py
@@ -36,6 +36,7 @@ def test_get_session_tag_missing_global(monkeypatch, caplog):
     monkeypatch.delattr(features, 'SESSION_TIMES_UTC', raising=False)
     from src import utils
     monkeypatch.delattr(utils.sessions, 'SESSION_TIMES_UTC', raising=False)
+    utils.sessions._WARNED_OUT_OF_RANGE.clear()
     ts = pd.Timestamp('2024-01-01 05:00', tz='UTC')
     with caplog.at_level(logging.WARNING):
         tag = utils.sessions.get_session_tag(ts)


### PR DESCRIPTION
## Summary
- update expected line numbers in registry tests
- ensure `src.config` can be reloaded in temporary config path test
- reload config safely in loader tests
- clear warning counters in session tag utilities tests
- update global session warning test

## Testing
- `pytest -q` *(fails: Line mismatch for validate_csv_data, safe removal, optuna sweep, fallback files, session tags)*

------
https://chatgpt.com/codex/tasks/task_e_68471f73b9e8832586d5dd0e779e192f