### PR TITLE
Patch v5.9.4 Improve file guard and session warnings

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1039,9 +1039,8 @@ def clean_test_file(test_file_path: str) -> None:
     import logging
     from src import config as cfg
     logger = logging.getLogger(__name__)
-    abs_path = os.path.realpath(test_file_path)
-    data_dir = os.path.realpath(str(cfg.DATA_DIR))
-    if abs_path.startswith(data_dir):
+    abs_path = os.path.realpath(test_file_path); data_dir = os.path.realpath(str(cfg.DATA_DIR))
+    if abs_path.startswith(data_dir) or os.path.commonpath([abs_path, data_dir]) == data_dir:
         os.remove(test_file_path)
     else:
 # noinspection PyUnresolvedReferences

--- a/src/utils/sessions.py
+++ b/src/utils/sessions.py
@@ -58,12 +58,8 @@ def get_session_tag(
             warned_set = _WARNED_OUT_OF_RANGE
     else:
         session_times_utc_local = session_times_utc
-        key = id(session_times_utc)
-        entry = _WARNED_OUT_OF_RANGE_CUSTOM.get(key)
-        if entry is None or entry[0] is not session_times_utc:
-            entry = (session_times_utc, set())
-            _WARNED_OUT_OF_RANGE_CUSTOM[key] = entry
-        warned_set = entry[1]
+        key = frozenset(session_times_utc.items())
+        warned_set = _WARNED_OUT_OF_RANGE_CUSTOM.setdefault(key, set())
 
     if pd.isna(timestamp):
         return "N/A"


### PR DESCRIPTION
## Summary
- tweak `clean_test_file` logic
- handle custom session warning tracking using frozenset

## Testing
- `python run_tests.py --fast` *(fails: 2 failed, 877 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68473af313908325a7809eaddc0446bf