### PR TITLE
Fix failing test and remove warnings

### DIFF
--- a/src/adaptive.py
+++ b/src/adaptive.py
@@ -8,7 +8,9 @@ import warnings
 try:
     import torch
 except Exception as e:  # ModuleNotFoundError or OSError
-    warnings.warn(f"torch unavailable ({e}), defaulting to CPU-only mode")
+    logging.warning(
+        "torch unavailable (%s), defaulting to CPU-only mode", e
+    )  # [Patch] use logging to avoid runtime warning
 
     class _DummyCuda:
         def is_available(self):

--- a/src/log_analysis.py
+++ b/src/log_analysis.py
@@ -250,7 +250,12 @@ def calculate_expectancy_by_period(
         avg_loss = abs(losses.mean()) if not losses.empty else 0.0
         return float(win_rate * avg_win - (1 - win_rate) * avg_loss)
 
-    grouped = df.groupby(df["EntryTime"].dt.to_period(period.lower()))[pnl_col]
+    entry_time = df["EntryTime"]
+    if entry_time.dt.tz is not None:
+        entry_time = entry_time.dt.tz_localize(None)
+    grouped = df.groupby(
+        entry_time.dt.to_period(period.lower())
+    )[pnl_col]  # [Patch] handle timezone to avoid warning
     return grouped.apply(_exp)
 
 

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -21,7 +21,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m1", 1009),
     ("src/data_loader.py", "load_raw_data_m15", 1020),
     ("src/data_loader.py", "write_test_file", 1025),
-    ("src/data_loader.py", "validate_csv_data", 1047),
+    ("src/data_loader.py", "validate_csv_data", 1054),
 
     ("src/features.py", "tag_price_structure_patterns", 473),
     ("src/features.py", "calculate_trend_zone", 1533),


### PR DESCRIPTION
## Summary
- update validate_csv_data line number in function registry test
- drop timezone before period conversion in log analysis
- log missing torch warning via logging module

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6847774e38608325a8dd83827057c828