### PR TITLE
[Patch v6.3.0] เพิ่มคำอธิบายก่อนรัน sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ python ProjectP.py --mode all
 ## การใช้งานสคริปต์หลัก
 - `python ProjectP.py` เตรียมข้อมูลพื้นฐานและรันขั้นตอนหลัก
 - `python tuning/hyperparameter_sweep.py` รันฝึกโมเดลหลายค่าพารามิเตอร์
+- ก่อนรัน sweep ควรสั่ง `python main.py --stage all` เพื่อสร้างไฟล์ `logs/trade_log_<DATE>.csv` ให้ครบถ้วน
 - `python threshold_optimization.py` หา threshold ที่ดีที่สุดด้วย Optuna
 - `python main.py --stage backtest` รัน backtest พร้อม config ใน `config/pipeline.yaml`
 - `python main.py --stage all` ทำ Walk-Forward Validation ทั้งชุด
@@ -225,7 +226,7 @@ fig.savefig('summary.png')
 Updated for patch 5.8.5.
 
 Patch 5.7.8 resolves font configuration parsing errors when plotting.
-
-
+## สรุป Metrics หลัง Hyperparameter Sweep
+เมื่อรัน `python tuning/hyperparameter_sweep.py` จนครบทุกค่าแล้ว ให้นำผล AUC/K-Fold จากแต่ละรอบมาเขียนลงไฟล์ `metrics_summary.csv` และแสดงคอนฟิกที่มีค่า AUC สูงสุด 5 อันดับแรกบนหน้าจอ
 ## Vendored Libraries
 โฟลเดอร์ `vendor/ta/` นำโค้ดไลบรารี ta เวอร์ชัน 0.11.0 มารวมไว้เป็นสำรอง หากไม่ต้องการสามารถติดตั้ง `ta` จาก PyPI และลบโฟลเดอร์นี้ได้

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ python profile_backtest.py XAUUSD_M1.csv --rows 1000 --console_level WARNING
 ## การใช้งานสคริปต์
 - `python ProjectP.py` เตรียมข้อมูลและเรียก pipeline หลัก
 - `python tuning/hyperparameter_sweep.py` ทดสอบค่า hyperparameter
+- ก่อนรัน sweep ต้องทำ Walk-Forward Validation ให้สร้างไฟล์ `logs/trade_log_<DATE>.csv` ให้เรียบร้อย
 - `python main.py --stage backtest` รัน backtest ตามค่าใน `config/pipeline.yaml`
 - `python profile_backtest.py <CSV>` ตรวจสอบ bottleneck
 - ระบบมีตัวกรองความผันผวน (Volatility Filter) ไม่เปิดออร์เดอร์หากค่า `Volatility_Index` ต่ำกว่า 1.0
@@ -38,3 +39,6 @@ flowchart TD
     C --> D[Meta-Model Training]
     D --> E[Export Artifacts]
 ```
+
+## การสรุป Metrics หลัง Sweep
+หลังจากจบการรัน `tuning/hyperparameter_sweep.py` ให้นำผล AUC/K-Fold จากทุกรอบมาเก็บในไฟล์ `metrics_summary.csv` และแสดงคอนฟิกอันดับสูงสุด 5 รายการบนหน้าจอ


### PR DESCRIPTION
## Summary
- ระบุใน README และ docs ว่าต้องทำ Walk-Forward Validation ให้สร้าง `logs/trade_log_<DATE>.csv` ก่อนรัน hyperparameter sweep
- เพิ่มขั้นตอนสรุป AUC/K-Fold หลัง sweep ลง `metrics_summary.csv` พร้อมบอกให้แสดง top 5 configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479eff59d0832594fe560fe65e2633