### PR TITLE
[Patch v6.3.5] บังคับใช้ trade log จริงในการ sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2025-06-24
+- [Patch v6.3.5] Disable dummy trade log fallback; require real walk-forward log
+- New/Updated unit tests added for tests/test_hyperparameter_sweep_cli.py
+- QA: pytest -q passed
 
 ### 2025-06-23
 - [Patch v6.2.3] Integrate Auto Threshold Optimization, Meta-Classifier Training & Dashboard Generation

--- a/tests/test_hyperparameter_sweep_cli.py
+++ b/tests/test_hyperparameter_sweep_cli.py
@@ -77,12 +77,8 @@ def test_run_sweep_filters_unknown_params(tmp_path, monkeypatch):
 def test_run_sweep_no_log(tmp_path):
     grid = {'p': [1]}
     missing = tmp_path / 'missing.csv'
-    hs.run_sweep(str(tmp_path), grid, trade_log_path=str(missing))
-    assert missing.exists()
-    df_log = pd.read_csv(missing)
-    assert len(df_log) > 1
-    df = pd.read_csv(tmp_path / 'summary.csv')
-    assert len(df) == 1
+    with pytest.raises(SystemExit):
+        hs.run_sweep(str(tmp_path), grid, trade_log_path=str(missing))
 
 
 def test_parse_args_defaults():

--- a/tuning/hyperparameter_sweep.py
+++ b/tuning/hyperparameter_sweep.py
@@ -97,17 +97,19 @@ def run_sweep(
         if os.path.exists(alt):
             trade_log_path = alt
         else:
-            logger.warning(f"ไม่พบไฟล์ trade log: {trade_log_path} จะสร้างไฟล์ตัวอย่าง")
-            _create_placeholder_trade_log(trade_log_path)
+            logger.error(
+                "Missing real walk-forward trade log: %s. Aborting sweep",
+                trade_log_path,
+            )
+            raise SystemExit(1)
     try:
         df_log = pd.read_csv(trade_log_path)
         # [Patch v5.8.13] Allow single-row trade logs with fallback metrics
         if len(df_log) < 1:
-            logger.warning(
-                "trade log มีข้อมูลน้อยกว่า 1 แถว - สร้างไฟล์ตัวอย่างเพิ่ม"
+            logger.error(
+                "trade log มีข้อมูลน้อยกว่า 1 แถว - ต้องใช้ walk-forward log ที่แท้จริง"
             )
-            _create_placeholder_trade_log(trade_log_path)
-            df_log = pd.read_csv(trade_log_path)
+            raise SystemExit(1)
     except Exception as e:  # pragma: no cover - unexpected read failure
         logger.error(f"อ่านไฟล์ trade log ไม่สำเร็จ: {e}")
         raise SystemExit(1)


### PR DESCRIPTION
## Summary
- ยกเลิกการสร้าง trade log ตัวอย่างเมื่อไม่พบไฟล์จริง
- ปรับ test ให้คาดหวังการออกจากโปรแกรมเมื่อ trade log หาย
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479edc8e748325a27b15d0486da3f5