### PR TITLE
[Patch v6.3.0] Add stubs for missing dashboard helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2025-06-25
+- [Patch v6.3.0] Add stubs for auto_train_meta_classifiers and generate_dashboard
+- QA: pytest -q failed due to environment limitations
+
 ### 2025-06-24
 - [Patch v6.3.5] Disable dummy trade log fallback; require real walk-forward log
 - New/Updated unit tests added for tests/test_hyperparameter_sweep_cli.py

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -1,6 +1,23 @@
 """Bootstrap script for running the main entry point."""
 
 import logging
+
+# [Patch v6.3.0] Stub imports for missing features
+try:
+    from src.utils.auto_train_meta_classifiers import auto_train_meta_classifiers
+except ImportError:  # pragma: no cover - fallback when module missing
+    def auto_train_meta_classifiers(*args, **kwargs):
+        logging.getLogger().warning(
+            "[Patch v6.2.3] auto_train_meta_classifiers stub invoked; skipping."
+        )
+
+try:
+    from reporting.dashboard import generate_dashboard
+except ImportError:  # pragma: no cover - fallback when module missing
+    def generate_dashboard(*args, **kwargs):
+        logging.getLogger().warning(
+            "[Patch v6.2.3] generate_dashboard stub invoked; skipping."
+        )
 import csv
 from pathlib import Path
 try:  # [Patch v5.10.2] allow import without heavy dependencies


### PR DESCRIPTION
## Summary
- stub `auto_train_meta_classifiers` import
- stub `generate_dashboard` import
- update CHANGELOG

## Testing
- `python run_tests.py --fast` *(fails: SystemExit due to missing output files)*

------
https://chatgpt.com/codex/tasks/task_e_6847aa7019b483258ab72afc51703f21