### PR TITLE
[Patch v6.3.0] Create reporting.dashboard.generate_dashboard stub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,8 +237,10 @@
   - Develop HTML/JavaScript dashboards (e.g., with Plotly or Dash) for executive summaries
   - New module `src.dashboard` generates Plotly HTML dashboards for WFV results
   - New module `src/realtime_dashboard.py` provides Streamlit-based real-time monitoring
+  - New module `reporting/dashboard.py` contains a stubbed result dashboard generator
 - **Modules:** `src/dashboard.py`
   `src/realtime_dashboard.py`
+  `reporting/dashboard.py`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-06-25
+- [Patch v6.3.0] Create reporting.dashboard.generate_dashboard stub
+- New/Updated unit tests added for tests/test_reporting_dashboard.py
+- QA: pytest -q passed
+
 ### 2025-06-24
 - [Patch v6.3.5] Disable dummy trade log fallback; require real walk-forward log
 - New/Updated unit tests added for tests/test_hyperparameter_sweep_cli.py

--- a/reporting/dashboard.py
+++ b/reporting/dashboard.py
@@ -1,0 +1,13 @@
+"""
+reporting.dashboard module stub.
+Provides a placeholder for dashboard generation logic.
+"""
+
+
+def generate_dashboard(*args, **kwargs):
+    """Placeholder for generating HTML/JavaScript dashboard."""
+    # TODO: integrate Plotly/D3.js or static HTML template.
+    results = kwargs.get("results") if "results" in kwargs else (args[0] if args else None)
+    output_path = kwargs.get("output_filepath") or kwargs.get("output_html")
+    print(f"[Dashboard Stub] Called with results={results}, output={output_path}")
+    return None

--- a/tests/test_reporting_dashboard.py
+++ b/tests/test_reporting_dashboard.py
@@ -1,0 +1,8 @@
+from reporting.dashboard import generate_dashboard
+
+
+def test_generate_dashboard_stub(capsys):
+    result = generate_dashboard({'a': 1}, output_filepath='out.html', extra=2)
+    captured = capsys.readouterr()
+    assert '[Dashboard Stub] Called' in captured.out
+    assert result is None


### PR DESCRIPTION
## Summary
- add `reporting/dashboard.py` stub module with `generate_dashboard`
- reference new module in AGENTS
- add changelog entry
- unit tests for the dashboard stub

## Testing
- `pytest tests/test_reporting_dashboard.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847aa7d5de483258d37fc79250581bd