### PR TITLE
[Patch v6.4.1] Fix meta-classifier invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### 2025-06-26
+- [Patch v6.4.1] Fix meta-classifier auto-training invocation
+- Load walk-forward trade log before calling auto_train_meta_classifiers
+- QA: pytest -q passed (883 tests)
+
+### 2025-06-26
 - [Patch v6.4.0] Ensure project modules importable by setting sys.path and working directory
 - QA: pytest -q failed (3 failures)
 

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -300,13 +300,18 @@ if __name__ == "__main__":
 
         try:
             from src.evaluation import auto_train_meta_classifiers
-            logger.info("[Patch v6.2.3] Auto-training missing meta-classifiers...")
+            logger.info("[Patch v6.4.1] Auto-training missing meta-classifiers...")
+            trade_log_path = os.path.join(
+                cfg.OUTPUT_DIR, "trade_log_v32_walkforward.csv.gz"
+            )
+            training_data = pd.read_csv(trade_log_path, compression="gzip")
             auto_train_meta_classifiers(
-                trade_log=os.path.join(cfg.OUTPUT_DIR, "trade_log_v32_walkforward.csv.gz"),
+                cfg,
+                training_data,
                 models_dir=getattr(cfg, "MODELS_DIR", cfg.OUTPUT_DIR),
                 features_dir=cfg.OUTPUT_DIR,
             )
-            logger.info("[Patch v6.2.3] Meta-Classifier Training Completed.")
+            logger.info("[Patch v6.4.1] Meta-Classifier Training Completed.")
         except ImportError:
             logger.warning("[Patch v6.2.3] auto_train_meta_classifiers not found; skipping.")
 

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -47,7 +47,7 @@ FUNCTIONS_INFO = [
     ("src/strategy.py", "log_trade", 4631),
     ("src/strategy.py", "aggregate_fold_results", 4634),
 
-    ("ProjectP.py", "custom_helper_function", 67),
+    ("ProjectP.py", "custom_helper_function", 95),
 ]
 
 

--- a/tests/test_projectp_nvml.py
+++ b/tests/test_projectp_nvml.py
@@ -5,6 +5,8 @@ import types
 import sys
 import logging
 import os
+from pathlib import Path
+import pandas as pd
 import pytest
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -28,8 +30,23 @@ def test_projectp_import_without_pynvml(monkeypatch):
     assert module.nvml_handle is None
 
 
-def test_projectp_main_logs_gpu_status(monkeypatch, caplog):
+def test_projectp_main_logs_gpu_status(monkeypatch, caplog, tmp_path):
     """Running the script should log GPU availability."""
+    out_dir = Path("output_default")
+    out_dir.mkdir(exist_ok=True)
+    for name in [
+        "features_main.json",
+        "trade_log_BUY.csv",
+        "trade_log_SELL.csv",
+        "trade_log_NORMAL.csv",
+    ]:
+        (out_dir / name).write_text("")
+    pd.DataFrame({"col": [1]}).to_csv(
+        out_dir / "trade_log_v32_walkforward.csv.gz",
+        index=False,
+        compression="gzip",
+    )
+
     dummy_main = lambda: None
     monkeypatch.setitem(sys.modules, "src.main", types.SimpleNamespace(main=dummy_main))
     monkeypatch.setattr(sys, "argv", ["ProjectP.py"])
@@ -38,8 +55,23 @@ def test_projectp_main_logs_gpu_status(monkeypatch, caplog):
     assert any("GPU not available" in m for m in caplog.messages)
 
 
-def test_projectp_logs_gpu_release(monkeypatch, caplog):
+def test_projectp_logs_gpu_release(monkeypatch, caplog, tmp_path):
     """NVML handle should be shut down and logged."""
+    out_dir = Path("output_default")
+    out_dir.mkdir(exist_ok=True)
+    for name in [
+        "features_main.json",
+        "trade_log_BUY.csv",
+        "trade_log_SELL.csv",
+        "trade_log_NORMAL.csv",
+    ]:
+        (out_dir / name).write_text("")
+    pd.DataFrame({"col": [1]}).to_csv(
+        out_dir / "trade_log_v32_walkforward.csv.gz",
+        index=False,
+        compression="gzip",
+    )
+
     dummy_nvml = types.SimpleNamespace()
 
     def fake_shutdown():


### PR DESCRIPTION
## Summary
- fix call to `auto_train_meta_classifiers` with proper arguments
- load trade log DataFrame before training
- adjust tests for new training data requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848398cd9248325b9a49cd814353a4f