### PR TITLE
[Patch v6.4.5] support zipped trade log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2025-06-29
+- [Patch v6.4.5] Support zipped trade log detection in ProjectP
+- Updated ProjectP.py to search for `trade_log_*.csv.gz` if no CSV found
+- New/Updated unit tests added for tests/test_projectp_nvml.py
+- QA: pytest -q passed
+
 ### 2025-06-26
 - [Patch v6.4.1] Fix meta-classifier auto-training invocation
 - Load walk-forward trade log before calling auto_train_meta_classifiers

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -296,10 +296,13 @@ if __name__ == "__main__":
             os.path.getsize(features_path),
         )
 
-    # [Patch v6.4.4] Dynamic trade log detection
+    # [Patch v6.4.5] Dynamic trade log detection supports .csv and .csv.gz
     import glob
     trade_pattern = os.path.join(output_dir, "trade_log_*.csv")
     log_files = glob.glob(trade_pattern)
+    if not log_files:
+        trade_pattern_gz = os.path.join(output_dir, "trade_log_*.csv.gz")
+        log_files = glob.glob(trade_pattern_gz)
     if not log_files:
         logger.error("No trade_log CSV found in %s; aborting.", output_dir)
         sys.exit(1)

--- a/tests/test_projectp_nvml.py
+++ b/tests/test_projectp_nvml.py
@@ -125,3 +125,23 @@ def test_projectp_output_audit(monkeypatch, caplog, tmp_path):
     with caplog.at_level(logging.INFO):
         runpy.run_path(script_path, run_name="__main__")
     assert (out_dir / "features_main.json").exists()
+
+
+def test_projectp_detect_zipped_log(monkeypatch, tmp_path):
+    """Script should detect trade log when only a .csv.gz file is present."""
+    out_dir = tmp_path / "output_default"
+    out_dir.mkdir()
+    (out_dir / "features_main.json").write_text("{}")
+    pd.DataFrame({"col": [1]}).to_csv(
+        out_dir / "trade_log_v32_walkforward.csv.gz",
+        index=False,
+        compression="gzip",
+    )
+
+    dummy_main = lambda: None
+    monkeypatch.setitem(sys.modules, "src.main", types.SimpleNamespace(main=dummy_main))
+    monkeypatch.setattr(config, "OUTPUT_DIR", out_dir)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["ProjectP.py"])
+    script_path = os.path.join(ROOT_DIR, "ProjectP.py")
+    runpy.run_path(script_path, run_name="__main__")


### PR DESCRIPTION
## Summary
- search for `.csv.gz` trade logs when `.csv` not found
- test ProjectP behaviour when only zipped logs exist
- document support for zipped trade logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684857046b648325b02d67c2a61d61c4