### PR TITLE
[Patch v6.4.6] Align DefaultConfig output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - New/Updated unit tests added for tests/test_projectp_nvml.py
 - QA: pytest -q passed
 
+### 2025-06-30
+- [Patch v6.4.6] Align DefaultConfig output path with global constant
+- Updated src/config to set DefaultConfig.OUTPUT_DIR to `OUTPUT_DIR`
+- QA: pytest -q passed (885 tests)
+
 ### 2025-06-26
 - [Patch v6.4.1] Fix meta-classifier auto-training invocation
 - Load walk-forward trade log before calling auto_train_meta_classifiers

--- a/src/config.py
+++ b/src/config.py
@@ -741,7 +741,7 @@ from dataclasses import dataclass
 
 @dataclass
 class DefaultConfig:
-    OUTPUT_DIR: str = DEFAULT_LOG_DIR
+    OUTPUT_DIR: str = str(OUTPUT_DIR)
     DATA_FILE_PATH_M1: str = DEFAULT_CSV_PATH_M1
     DATA_FILE_PATH_M15: str = DEFAULT_CSV_PATH_M15
     DEFAULT_RISK_PER_TRADE: float = FUND_PROFILES.get(DEFAULT_FUND_NAME, {}).get("risk", 0.01)


### PR DESCRIPTION
## Summary
- unify output directories by pointing `DefaultConfig.OUTPUT_DIR` to the main `OUTPUT_DIR`
- document change in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684860cb3ba08325be3e069e1e0b61b1