### PR TITLE
[Patch v6.4.6] Graceful trade log fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Updated tests for new validation logic
 - QA: pytest -q passed (886 tests)
 
+### 2025-07-16
+- [Patch v6.4.6] Graceful fallback when trade log missing
+- Updated ProjectP.py to create dummy log and warn
+- New/Updated unit tests added for tests/test_projectp_fallback.py
+- QA: pytest -q passed (889 tests)
+
 ### 2025-06-29
 - [Patch v6.4.5] Support zipped trade log detection in ProjectP
 - Updated ProjectP.py to search for `trade_log_*.csv.gz` if no CSV found

--- a/tests/test_projectp_fallback.py
+++ b/tests/test_projectp_fallback.py
@@ -4,26 +4,43 @@ import sys
 import os
 import json
 from pathlib import Path
+import pandas as pd
 import pytest
 import src.config as config
+import ProjectP
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT_DIR)
 
 
-def test_missing_outputs_abort(monkeypatch, tmp_path):
-    """หากไม่มีไฟล์ผลลัพธ์สคริปต์ควรหยุดการทำงาน"""
+def test_missing_outputs_creates_dummy(monkeypatch, tmp_path, caplog):
+    """เมื่อไม่มีไฟล์ trade_log สคริปต์ควรสร้างไฟล์เปล่าสำหรับทำงานต่อ"""
     out_dir = tmp_path / "output_default"
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(config, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(config, "OUTPUT_DIR", str(out_dir))
     monkeypatch.setattr(config, "DATA_DIR", Path(ROOT_DIR))
+    out_dir.mkdir()
+    # Pre-create features_main.json to skip heavy generation
+    (out_dir / "features_main.json").write_text("[]")
+    # Skip real meta-classifier training to avoid file dependency
+    monkeypatch.setattr(
+        "src.evaluation.auto_train_meta_classifiers",
+        lambda *a, **k: None,
+        raising=False,
+    )
+    orig_read_csv = ProjectP.pd.read_csv
+
+    def fake_read_csv(path, *args, **kwargs):
+        if str(path).endswith("trade_log_v32_walkforward.csv.gz"):
+            return pd.DataFrame()
+        return orig_read_csv(path, *args, **kwargs)
+
+    monkeypatch.setattr(ProjectP.pd, "read_csv", fake_read_csv)
     dummy_main = lambda: None
     monkeypatch.setitem(sys.modules, "src.main", types.SimpleNamespace(main=dummy_main))
     monkeypatch.setattr(sys, "argv", ["ProjectP.py"])
     script_path = os.path.join(ROOT_DIR, "ProjectP.py")
-    with pytest.raises(SystemExit) as exc:
+    with caplog.at_level("WARNING"):
         runpy.run_path(script_path, run_name="__main__")
-    assert exc.value.code == 1
-    # trade_log_*.csv ไม่ควรสร้างขึ้น
-    for name in ["trade_log_BUY.csv", "trade_log_SELL.csv", "trade_log_NORMAL.csv"]:
-        assert not (out_dir / name).exists()
+    assert (out_dir / "trade_log_dummy.csv").exists()
+    assert (out_dir / "features_main.json").exists()

--- a/tests/test_projectp_feature_utils.py
+++ b/tests/test_projectp_feature_utils.py
@@ -21,3 +21,9 @@ def test_generate_all_features_basic(tmp_path):
     df.to_csv(csv, index=False)
     feats = ProjectP.generate_all_features([str(csv)])
     assert "A" in feats and "B" in feats and "label" not in feats
+
+
+def test_generate_all_features_missing_file(caplog):
+    ProjectP.configure_logging()
+    feats = ProjectP.generate_all_features(["no_data.csv"])
+    assert feats == []


### PR DESCRIPTION
## Summary
- warn when raw CSV missing and return empty features
- create dummy trade log when no logs found
- adjust fallback test for new behaviour
- check feature generation handles missing file
- document in CHANGELOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848712ce4348325afe7558946144d9d