### PR TITLE
[Patch v6.5.6] Continue pipeline on insufficient rows

### DIFF
--- a/ProjectP.py
+++ b/ProjectP.py
@@ -319,8 +319,8 @@ def generate_all_features(raw_data_paths: list[str]) -> list[str]:
 def load_trade_log(path: str, min_rows: int = 10) -> pd.DataFrame:
     """Load trade log CSV with strict validation.
 
-    [Patch v6.5.4] Raise detailed errors if the file is empty, malformed,
-    or does not contain the minimum required number of rows.
+    [Patch v6.5.6] Raise detailed errors if the file is empty or malformed.
+    Log a warning instead of raising when row count is below minimum.
     """
     logger.info(f"[Patch v6.5.4] Attempting to load trade log from {path}")
     try:
@@ -337,10 +337,10 @@ def load_trade_log(path: str, min_rows: int = 10) -> pd.DataFrame:
 
     row_count = len(df)
     if row_count < min_rows:
-        logger.critical(
-            f"[Patch v6.5.4] Insufficient trade rows ({row_count}); minimum required: {min_rows}"
+        # Log a warning and continue pipeline even when trade log has fewer rows than expected
+        logger.warning(
+            f"[Patch v6.5.6] Insufficient trade rows: {row_count}/{min_rows}, proceeding with available data"
         )
-        raise ValueError(f"Insufficient trade rows: {row_count}/{min_rows}")
     return df
 
 

--- a/commit_message_ProjectP.txt
+++ b/commit_message_ProjectP.txt
@@ -1,0 +1,7 @@
+[Patch v6.5.6] Continue pipeline on insufficient trade log rows
+
+Purpose/Key Changes:
+
+Removed ValueError raise to prevent pipeline termination when trade log entries < min_rows.
+
+Consolidated logging into a warning to inform of insufficient data while allowing execution to continue.

--- a/tests/test_projectp_insufficient_rows.py
+++ b/tests/test_projectp_insufficient_rows.py
@@ -1,41 +1,27 @@
-import runpy
-import types
-import sys
-import os
+import logging
 from pathlib import Path
 import pandas as pd
-import pytest
-import src.config as config
 import ProjectP
-
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 
 def test_insufficient_rows_logs_warning(monkeypatch, tmp_path, caplog):
-    out_dir = tmp_path / "output_default"
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(config, "OUTPUT_DIR", str(out_dir))
-    monkeypatch.setattr(config, "DATA_DIR", Path(ROOT_DIR))
-    out_dir.mkdir()
-    (out_dir / "features_main.json").write_text("[]")
-    trade_file = out_dir / "trade_log_test.csv"
-    trade_file.write_text("")
+    csv_path = tmp_path / "log.csv"
+    csv_path.write_text("")
 
-    monkeypatch.setattr(
-        "src.evaluation.auto_train_meta_classifiers", lambda *a, **k: None, raising=False
-    )
     orig_read_csv = ProjectP.pd.read_csv
 
     def fake_read_csv(path, *args, **kwargs):
-        p = Path(path)
-        if p == trade_file or p.name == "trade_log_v32_walkforward.csv.gz":
+        if Path(path) == csv_path:
             return pd.DataFrame()
         return orig_read_csv(path, *args, **kwargs)
 
+    test_logger = logging.getLogger("test_logger")
+    test_logger.setLevel(logging.WARNING)
+    monkeypatch.setattr(ProjectP, "logger", test_logger)
     monkeypatch.setattr(ProjectP.pd, "read_csv", fake_read_csv)
-    dummy_main = lambda: None
-    monkeypatch.setitem(sys.modules, "src.main", types.SimpleNamespace(main=dummy_main))
-    monkeypatch.setattr(sys, "argv", ["ProjectP.py"])
-    script_path = os.path.join(ROOT_DIR, "ProjectP.py")
-    with pytest.raises(ValueError):
-        runpy.run_path(script_path, run_name="__main__")
+    with caplog.at_level(logging.WARNING, logger="test_logger"):
+        df = ProjectP.load_trade_log(str(csv_path), min_rows=10)
+    assert df.empty
+    assert any(
+        "Insufficient trade rows" in rec.getMessage() for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- update `load_trade_log` to warn and continue when trade rows < min_rows
- add regression test for warning on insufficient rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e2b942908325b93753cbf4f444fd