### PR TITLE
[Patch v6.5.5] Implement meta-classifier training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1591,3 +1591,9 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.5.4] Fix default variable initialization
 - Corrected DEFAULT_FUND_NAME, DEFAULT_MODEL_TO_LINK, and DEFAULT_RISK_PER_TRADE fallbacks
 - QA: pytest -q passed (895 tests)
+
+### 2025-07-20
+- [Patch v6.5.5] Implement meta-classifier training logic
+- Updated src/utils/auto_train_meta_classifiers.py with logistic regression
+- New tests for auto_train_meta_classifiers covering training behavior
+- QA: pytest -q passed (896 tests)

--- a/src/utils/auto_train_meta_classifiers.py
+++ b/src/utils/auto_train_meta_classifiers.py
@@ -9,13 +9,20 @@ from typing import Any
 import os
 import glob
 import pandas as pd
+from joblib import dump
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, roc_auc_score
 from src.config import logger
+from src.utils import load_json_with_comments
 
 
 def auto_train_meta_classifiers(
-    config: Any, training_data: Any | None = None, **kwargs
-) -> None:
-    """[Patch v6.4.2] Auto train meta-classifiers if trade log exists."""
+    config: Any,
+    training_data: Any | None = None,
+    models_dir: str | None = None,
+    features_dir: str | None = None,
+) -> dict | None:
+    """[Patch v6.5.5] Auto train meta-classifiers if trade log exists."""
     if training_data is None:
         pattern = os.path.join(config.OUTPUT_DIR, "trade_log_v32_walkforward*.csv.gz")
         matches = glob.glob(pattern)
@@ -36,5 +43,50 @@ def auto_train_meta_classifiers(
             logger.error("[Patch v6.4.2] Failed to load %s: %s", trade_log_path, e)
             return None
 
-    # TODO: implement actual training logic
-    return None
+    if not isinstance(training_data, pd.DataFrame):
+        logger.error("[Patch v6.5.5] Training data must be a DataFrame")
+        return None
+
+    if features_dir is None:
+        features_dir = getattr(config, "OUTPUT_DIR", ".")
+    features_path = os.path.join(features_dir, "features_main.json")
+    try:
+        features = load_json_with_comments(features_path)
+        if not isinstance(features, list):
+            raise ValueError("Invalid format")
+    except Exception as e:
+        logger.error("[Patch v6.5.5] Failed to load features file: %s", e)
+        return None
+
+    if "target" not in training_data.columns:
+        logger.error("[Patch v6.5.5] Training data missing 'target' column")
+        return None
+
+    missing = [c for c in features if c not in training_data.columns]
+    if missing:
+        logger.error("[Patch v6.5.5] Training data missing features: %s", missing)
+        return None
+
+    if len(training_data) < 5:
+        logger.error(
+            "[Patch v6.5.5] Insufficient rows for training: %d", len(training_data)
+        )
+        return None
+
+    X = training_data[features]
+    y = training_data["target"]
+
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X, y)
+
+    proba = model.predict_proba(X)[:, 1]
+    acc = accuracy_score(y, (proba >= 0.5).astype(int))
+    auc = roc_auc_score(y, proba)
+
+    if models_dir is None:
+        models_dir = getattr(config, "OUTPUT_DIR", ".")
+    os.makedirs(models_dir, exist_ok=True)
+    model_path = os.path.join(models_dir, "meta_classifier.joblib")
+    dump(model, model_path)
+    logger.info("[Patch v6.5.5] Meta-classifier trained: %s", model_path)
+    return {"model_path": model_path, "metrics": {"accuracy": acc, "auc": auc}}

--- a/tests/test_auto_train_meta_classifiers.py
+++ b/tests/test_auto_train_meta_classifiers.py
@@ -7,15 +7,26 @@ from src.utils.auto_train_meta_classifiers import auto_train_meta_classifiers
 from src.config import logger
 
 
-def test_auto_train_meta_classifiers_loads_trade_log(tmp_path, caplog):
-    """Should load trade log file when present."""
+def test_auto_train_meta_classifiers_loads_and_trains(tmp_path, caplog):
+    """Should load trade log file and train model when present."""
     cfg = SimpleNamespace(OUTPUT_DIR=str(tmp_path))
-    df = pd.DataFrame({"x": [1]})
-    df.to_csv(Path(cfg.OUTPUT_DIR) / "trade_log_v32_walkforward.csv.gz", index=False, compression="gzip")
+    df = pd.DataFrame({"x": [1, 0, 1, 0, 1], "target": [1, 0, 1, 0, 1]})
+    df.to_csv(
+        Path(cfg.OUTPUT_DIR) / "trade_log_v32_walkforward.csv.gz",
+        index=False,
+        compression="gzip",
+    )
+    (tmp_path / "features_main.json").write_text("[\"x\"]")
     with caplog.at_level('INFO', logger=logger.name):
-        result = auto_train_meta_classifiers(cfg, None)
-    assert result is None
-    assert any("Patch v6.4.2" in m and "Loading trade log" in m for m in caplog.messages)
+        result = auto_train_meta_classifiers(
+            cfg,
+            None,
+            models_dir=str(tmp_path),
+            features_dir=str(tmp_path),
+        )
+    assert isinstance(result, dict) and "model_path" in result
+    assert Path(result["model_path"]).exists()
+    assert any("Meta-classifier trained" in m for m in caplog.messages)
 
 
 def test_auto_train_meta_classifiers_missing_trade_log(tmp_path, caplog):
@@ -25,3 +36,15 @@ def test_auto_train_meta_classifiers_missing_trade_log(tmp_path, caplog):
         result = auto_train_meta_classifiers(cfg, None)
     assert result is None
     assert any("Patch v6.4.2" in m and "not found" in m for m in caplog.messages)
+
+
+def test_auto_train_meta_classifiers_with_data(tmp_path):
+    """Should train using provided DataFrame."""
+    cfg = SimpleNamespace(OUTPUT_DIR=str(tmp_path))
+    (tmp_path / "features_main.json").write_text("[\"f\"]")
+    data = pd.DataFrame({"f": [0, 1, 0, 1, 0, 1], "target": [0, 1, 0, 1, 0, 1]})
+    res = auto_train_meta_classifiers(
+        cfg, data, models_dir=str(tmp_path), features_dir=str(tmp_path)
+    )
+    assert Path(res["model_path"]).exists()
+


### PR DESCRIPTION
## Summary
- implement logistic regression training in `auto_train_meta_classifiers`
- extend tests for meta-classifier training
- document changes in `CHANGELOG`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e7e9f53883259812675f829e4ee5