### PR TITLE
[Patch v6.5.9] ENV-friendly config import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1591,3 +1591,9 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.5.4] Fix default variable initialization
 - Corrected DEFAULT_FUND_NAME, DEFAULT_MODEL_TO_LINK, and DEFAULT_RISK_PER_TRADE fallbacks
 - QA: pytest -q passed (895 tests)
+### 2025-07-20
+- [Patch v6.5.9] ENV-friendly config import
+- Updated src.config with env variable DEFAULT_TRADE_LOG_MIN_ROWS
+- Updated tests/test_function_registry.py for new line numbers
+- QA: pytest -q passed (895 tests)
+

--- a/src/config.py
+++ b/src/config.py
@@ -47,6 +47,7 @@ import sys
 import subprocess
 import importlib
 import sys
+# Imports
 import os
 import time
 import warnings
@@ -181,6 +182,8 @@ FOLD_ID = os.getenv('FOLD_ID', 'fold0')
 LOG_DIR = os.path.join(BASE_LOG_DIR, LOG_DATE, FOLD_ID)
 os.makedirs(LOG_DIR, exist_ok=True)
 LOG_FILENAME = os.path.join(LOG_DIR, f'gold_ai_v{__version__}_qa.log')
+# minimum rows required for trade log validation (override via TRADE_LOG_MIN_ROWS)
+DEFAULT_TRADE_LOG_MIN_ROWS = int(os.getenv("TRADE_LOG_MIN_ROWS", 10))
 
 # ตั้งค่า Logger กลางเพื่อให้โมดูลอื่น ๆ ใช้งานร่วมกัน
 # [Patch v5.5.6] Force COMPACT_LOG when running under pytest

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -4,11 +4,11 @@ import pytest
 
 # Mapping of module paths to function names and their expected starting line numbers
 FUNCTIONS_INFO = [
-    ("src/config.py", "log_library_version", 212),
-    ("src/config.py", "_ensure_ta_installed", 257),
-    ("src/config.py", "is_colab", 488),
-    ("src/config.py", "print_gpu_utilization", 588),
-    ("src/config.py", "show_system_status", 640),
+    ("src/config.py", "log_library_version", 215),
+    ("src/config.py", "_ensure_ta_installed", 260),
+    ("src/config.py", "is_colab", 491),
+    ("src/config.py", "print_gpu_utilization", 591),
+    ("src/config.py", "show_system_status", 643),
 
     ("src/data_loader.py", "inspect_file_exists", 911),
     ("src/data_loader.py", "read_csv_with_date_parse", 916),


### PR DESCRIPTION
## Summary
- เพิ่มคอมเมนต์ `Imports` ใน `src.config`
- เพิ่มตัวแปร `DEFAULT_TRADE_LOG_MIN_ROWS` อ่านจาก ENV
- ปรับเลขบรรทัดใน `tests/test_function_registry.py`
- บันทึกการเปลี่ยนแปลงใน `CHANGELOG`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848e94ed2988325873cfc76d0179b32