### PR TITLE
[Patch v6.5.14] Force single-fold regen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1637,4 +1637,10 @@ QA: pytest -q passed (219 tests)
 - New test tests/test_backtest_engine.py::test_run_backtest_engine_index_conversion
 - QA: pytest -q passed (906 tests)
 
+### 2025-07-24
+- [Patch v6.5.14] Force single-fold regen to fix empty trade log
+- Updated backtest_engine.py with DEFAULT_FOLD_CONFIG and DEFAULT_FOLD_INDEX
+- Added test_run_backtest_engine_passes_fold_params
+- QA: pytest -q passed (908 tests)
+
 

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -7,6 +7,10 @@ import pandas as pd
 from src.config import DATA_FILE_PATH_M1
 from src.strategy import run_backtest_simulation_v34
 
+# [Patch v6.5.14] Force fold 0 of 1 when regenerating the trade log
+DEFAULT_FOLD_CONFIG = {"n_folds": 1}
+DEFAULT_FOLD_INDEX = 0
+
 
 def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
     """Regenerate the trade log when the existing CSV has too few rows.
@@ -44,6 +48,8 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
         df,
         label="regen",
         initial_capital_segment=100.0,
+        fold_config=DEFAULT_FOLD_CONFIG,
+        current_fold_index=DEFAULT_FOLD_INDEX,
     )
 
     # 3) Extract and validate the trade log DataFrame

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -56,3 +56,24 @@ def test_run_backtest_engine_index_conversion(monkeypatch):
     assert result.equals(trade_df)
     assert captured['index_is_dt']
     assert 'tz_attr' in captured
+
+
+def test_run_backtest_engine_passes_fold_params(monkeypatch):
+    """ควรส่ง fold_config และ current_fold_index ให้ simulation"""
+    price_df = pd.DataFrame({'Open': [1], 'High': [1], 'Low': [1], 'Close': [1]})
+    trade_df = pd.DataFrame({'pnl': [1.0]})
+
+    captured = {}
+
+    def fake_simulation(df, **kwargs):
+        captured['fold_config'] = kwargs.get('fold_config')
+        captured['current_fold_index'] = kwargs.get('current_fold_index')
+        return None, trade_df
+
+    monkeypatch.setattr(be.pd, 'read_csv', lambda *a, **k: price_df)
+    monkeypatch.setattr(be, 'run_backtest_simulation_v34', fake_simulation)
+
+    result = be.run_backtest_engine(pd.DataFrame())
+    assert result.equals(trade_df)
+    assert captured['fold_config'] == be.DEFAULT_FOLD_CONFIG
+    assert captured['current_fold_index'] == be.DEFAULT_FOLD_INDEX


### PR DESCRIPTION
## Summary
- force single-fold backtest in `backtest_engine`
- add unit test verifying fold parameters
- document patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f768bfbc8325b74f455d4618ead5