### PR TITLE
[Patch v6.5.15] Run feature engineering before simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1650,4 +1650,11 @@ QA: pytest -q passed (219 tests)
 
 - QA: pytest -q passed (908 tests)
 
+### 2025-07-25
+
+- [Patch v6.5.15] Run feature engineering before simulation
+- Updated backtest_engine.run_backtest_engine to call engineer_m1_features
+- Expanded tests/test_backtest_engine.py to verify feature engineering call
+- QA: pytest -q passed (909 tests)
+
 

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from src.config import DATA_FILE_PATH_M1
 from src.strategy import run_backtest_simulation_v34
+from src.features import engineer_m1_features
 
 # [Patch v6.5.14] Force fold 0 of 1 when regenerating the trade log
 DEFAULT_FOLD_CONFIG = {"n_folds": 1}
@@ -43,16 +44,19 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
                 f"[backtest_engine] Failed to convert index to datetime: {e}"
             ) from e
 
-    # 2) Run your core simulation (returns tuple: (sim_df, trade_log_df, …))
+    # [Patch v6.5.15] Engineer features before simulation
+    features_df = engineer_m1_features(df)
+
+    # 3) Run your core simulation (returns tuple: (sim_df, trade_log_df, …))
     result = run_backtest_simulation_v34(
-        df,
+        features_df,
         label="regen",
         initial_capital_segment=100.0,
         fold_config=DEFAULT_FOLD_CONFIG,
         current_fold_index=DEFAULT_FOLD_INDEX,
     )
 
-    # 3) Extract and validate the trade log DataFrame
+    # 4) Extract and validate the trade log DataFrame
     try:
         trade_log_df = result[1]
     except Exception:

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -10,6 +10,7 @@ def test_run_backtest_engine_success(monkeypatch):
     trade_df = pd.DataFrame({'pnl': [1.0]})
 
     monkeypatch.setattr(be.pd, 'read_csv', lambda *a, **k: price_df)
+    monkeypatch.setattr(be, 'engineer_m1_features', lambda df, **k: df)
     monkeypatch.setattr(be, 'run_backtest_simulation_v34', lambda df, **k: (None, trade_df))
 
     result = be.run_backtest_engine(pd.DataFrame())
@@ -19,6 +20,7 @@ def test_run_backtest_engine_success(monkeypatch):
 def test_run_backtest_engine_fail_load(monkeypatch):
     """หากโหลดราคาล้มเหลวต้องยก RuntimeError"""
     monkeypatch.setattr(be.pd, 'read_csv', lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError('no')))
+    monkeypatch.setattr(be, 'engineer_m1_features', lambda df, **k: (_ for _ in ()).throw(AssertionError('should not be called')))
     with pytest.raises(RuntimeError):
         be.run_backtest_engine(pd.DataFrame())
 
@@ -27,6 +29,7 @@ def test_run_backtest_engine_empty_log(monkeypatch):
     """เมื่อ trade log ว่างต้องยก RuntimeError"""
     price_df = pd.DataFrame({'Open': [1], 'High': [1], 'Low': [1], 'Close': [1]})
     monkeypatch.setattr(be.pd, 'read_csv', lambda *a, **k: price_df)
+    monkeypatch.setattr(be, 'engineer_m1_features', lambda df, **k: df)
     monkeypatch.setattr(be, 'run_backtest_simulation_v34', lambda df, **k: (None, pd.DataFrame()))
     with pytest.raises(RuntimeError):
         be.run_backtest_engine(pd.DataFrame())
@@ -50,6 +53,7 @@ def test_run_backtest_engine_index_conversion(monkeypatch):
         return None, trade_df
 
     monkeypatch.setattr(be.pd, 'read_csv', lambda *a, **k: price_df)
+    monkeypatch.setattr(be, 'engineer_m1_features', lambda df, **k: df)
     monkeypatch.setattr(be, 'run_backtest_simulation_v34', fake_simulation)
 
     result = be.run_backtest_engine(pd.DataFrame())
@@ -71,9 +75,30 @@ def test_run_backtest_engine_passes_fold_params(monkeypatch):
         return None, trade_df
 
     monkeypatch.setattr(be.pd, 'read_csv', lambda *a, **k: price_df)
+    monkeypatch.setattr(be, 'engineer_m1_features', lambda df, **k: df)
     monkeypatch.setattr(be, 'run_backtest_simulation_v34', fake_simulation)
 
     result = be.run_backtest_engine(pd.DataFrame())
     assert result.equals(trade_df)
     assert captured['fold_config'] == be.DEFAULT_FOLD_CONFIG
     assert captured['current_fold_index'] == be.DEFAULT_FOLD_INDEX
+
+
+def test_run_backtest_engine_calls_feature_engineering(monkeypatch):
+    """ควรเรียก engineer_m1_features ก่อน simulation"""
+    price_df = pd.DataFrame({'Open': [1], 'High': [1], 'Low': [1], 'Close': [1]})
+    trade_df = pd.DataFrame({'pnl': [1.0]})
+
+    calls = {'count': 0}
+
+    def fake_engineer(df, **k):
+        calls['count'] += 1
+        return df
+
+    monkeypatch.setattr(be.pd, 'read_csv', lambda *a, **k: price_df)
+    monkeypatch.setattr(be, 'engineer_m1_features', fake_engineer)
+    monkeypatch.setattr(be, 'run_backtest_simulation_v34', lambda df, **k: (None, trade_df))
+
+    result = be.run_backtest_engine(pd.DataFrame())
+    assert result.equals(trade_df)
+    assert calls['count'] == 1


### PR DESCRIPTION
## Summary
- call `engineer_m1_features` inside backtest regeneration to avoid missing columns
- adjust `tests/test_backtest_engine.py` for new behavior
- document patch v6.5.15 in CHANGELOG

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6848f9ec6b84832595ee5e14b1108f91