### PR TITLE
[Patch v6.5.16] Cleanup duplicate imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1657,4 +1657,10 @@ QA: pytest -q passed (219 tests)
 - Expanded tests/test_backtest_engine.py to verify feature engineering call
 - QA: pytest -q passed (909 tests)
 
+### 2025-07-26
+
+- [Patch v6.5.16] Remove duplicate imports in src.strategy
+- Cleaned redundant function and module imports for clarity
+- QA: pytest -q passed (910 tests)
+
 

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -40,7 +40,6 @@ from src.config import (
     USE_RSI_SIGNALS,
     OUTPUT_DIR as CFG_OUTPUT_DIR,
 )
-from src.utils.env_utils import get_env_float
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +86,6 @@ from src.evaluation import find_best_threshold
 from src.adaptive import compute_dynamic_lot, atr_position_size, compute_trailing_atr_stop
 import gc # For memory management
 from src.utils.gc_utils import maybe_collect
-from src.utils.gc_utils import maybe_collect
-from src.utils.gc_utils import maybe_collect
-import os
 import itertools
 # Import ML libraries conditionally (assuming they are checked/installed in Part 1)
 try:
@@ -1090,17 +1086,11 @@ logging.info(f"Part 7: Model Training Function Loaded (v{__version__} Applied)."
 # <<< MODIFIED v4.8.8 (Patch 26.3.1): Applied [PATCH B] to _check_order_exit_conditions (new name & logic), verified BE-SL PnL and SL multiplier usage. >>>
 # <<< MODIFIED v4.8.8 (Patch 26.4.1): Unified [PATCH B] for logging in _update_open_order_state, and [PATCH C] for error handling in run_backtest_simulation_v34. >>>
 # <<< MODIFIED v4.8.8 (Patch 26.6.1): Applied user-provided fixes for f-string formatting in logging statements to prevent ValueError. >>>
-import logging
-import pandas as pd
-import numpy as np
 import random
-import time
 from collections import defaultdict
-import gc # For memory management
 import math # For math.isclose
 import importlib # Added for safe global access
 import sys # Added for safe global access
-import traceback # Added for [PATCH C]
 
 # Ensure tqdm is available (imported in Part 1)
 try:
@@ -2827,18 +2817,11 @@ logging.info(f"Part 8: Backtesting Engine Functions Loaded (v{__version__} Appli
 # <<< MODIFIED v4.7.9: Implemented logging, added docstrings/comments, enhanced analysis robustness, fixed SyntaxError, added memory cleanup >>>
 # <<< MODIFIED v4.8.1: Added input validation and handling for no trades in run_all_folds_with_threshold >>>
 # <<< MODIFIED v4.8.3: Applied SyntaxError fix for try-except global variable checks >>>
-import logging
-import os
-import pandas as pd
-import numpy as np
-import math
-import json
 import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm  # [Patch v5.7.7] Required for FontProperties
 from matplotlib.ticker import FuncFormatter
 from scipy.stats import ttest_ind, wasserstein_distance # For DriftObserver
 from sklearn.model_selection import TimeSeriesSplit # For Walk-Forward
-import gc # For memory management
 
 # Ensure global configurations are accessible if run independently
 # Define defaults if globals are not found

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -39,13 +39,13 @@ FUNCTIONS_INFO = [
     ("src/main.py", "save_final_data", 1939),
     ("src/main.py", "run_auto_threshold_stage", 1944),
 
-    ("src/strategy.py", "run_backtest_simulation_v34", 1951),
-    ("src/strategy.py", "calculate_metrics", 3250),
-    ("src/strategy.py", "initialize_time_series_split", 4622),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4625),
-    ("src/strategy.py", "apply_kill_switch", 4628),
-    ("src/strategy.py", "log_trade", 4631),
-    ("src/strategy.py", "aggregate_fold_results", 4634),
+    ("src/strategy.py", "run_backtest_simulation_v34", 1941),
+    ("src/strategy.py", "calculate_metrics", 3233),
+    ("src/strategy.py", "initialize_time_series_split", 4605),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4608),
+    ("src/strategy.py", "apply_kill_switch", 4611),
+    ("src/strategy.py", "log_trade", 4614),
+    ("src/strategy.py", "aggregate_fold_results", 4617),
 
     ("ProjectP.py", "custom_helper_function", 95),
 ]


### PR DESCRIPTION
## Summary
- deduplicate imports in `src/strategy.py`
- adjust function registry tests after line shifts
- document patch in `CHANGELOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ff898ebc8325828e3cd14585e892