### PR TITLE
[Patch v6.5.16] Vectorize convert_thai_datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1658,3 +1658,7 @@ QA: pytest -q passed (219 tests)
 - QA: pytest -q passed (909 tests)
 
 
+### 2025-07-26
+- [Patch v6.5.16] Vectorize convert_thai_datetime with logging
+- Updated tests/test_new_utils.py for new warning/error behavior
+- QA: pytest -q passed (910 tests)

--- a/tests/test_new_utils.py
+++ b/tests/test_new_utils.py
@@ -23,16 +23,12 @@ def test_print_qa_summary_empty_df(caplog):
     assert "ไม่มีไม้ที่ถูกเทรด" in caplog.text
 
 
-def test_convert_thai_datetime_invalid(tmp_path):
+def test_convert_thai_datetime_invalid(caplog):
     df = pd.DataFrame({"Date": ["abc"], "Timestamp": ["xx"]})
-    log_file = tmp_path / "error_log.txt"
-    os.chdir(tmp_path)
-    try:
+    with caplog.at_level(logging.ERROR):
         result = utils.convert_thai_datetime(df.copy())
-        assert result["timestamp"].isna().all()
-        assert log_file.exists()
-    finally:
-        os.chdir(ROOT_DIR)
+    assert result["timestamp"].isna().all()
+    assert "ไม่สามารถแปลงปี พ.ศ." in caplog.text
 
 
 def test_get_resource_plan_missing_modules(monkeypatch):
@@ -78,7 +74,8 @@ def test_prepare_csv_auto(tmp_path):
 def test_convert_thai_datetime_missing_cols():
     df = pd.DataFrame({"A": [1]})
     out = utils.convert_thai_datetime(df)
-    assert out is df
+    assert out.equals(df)
+    assert out is not df
 
 
 def test_get_resource_plan_with_gpu(monkeypatch):


### PR DESCRIPTION
## Summary
- vectorize `convert_thai_datetime` in utils
- adjust tests for new logging behavior
- document patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ff6c82a88325871eb4e383fae4f5