### PR TITLE
Fix duplicate Trend Zone indices in pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1699,3 +1699,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.6.1] Remove pandas datetime warnings
 - Updated backtest_engine to use date_format for M15 data
 - QA: pytest -q passed (911 tests)
+
+### 2025-07-29
+- [Patch v6.6.2] Drop duplicate Trend Zone indices before merge
+- New/Updated unit tests added for tests.test_backtest_engine.py::test_run_backtest_engine_drops_duplicate_trend_index
+- QA: pytest -q passed (1 test)

--- a/src/main.py
+++ b/src/main.py
@@ -898,6 +898,12 @@ def main(run_mode='FULL_PIPELINE', skip_prepare=False, suffix_from_prev_step=Non
                 sys.exit("ออก: ข้อมูล M15/M1 ว่างเปล่าหลัง prepare_datetime.")
 
             df_m15_trend = calculate_m15_trend_zone(df_m15_dt)
+            # [Patch v6.6.2] Remove duplicate index from Trend Zone before merge
+            if df_m15_trend.index.duplicated().any():
+                dup_count = int(df_m15_trend.index.duplicated().sum())
+                logging.warning("(Warning) พบ index ซ้ำซ้อนใน Trend Zone DataFrame, กำลังลบรายการซ้ำ (คงไว้ค่าแรกของแต่ละ index)")
+                df_m15_trend = df_m15_trend.loc[~df_m15_trend.index.duplicated(keep='first')]
+                logging.info(f"      Removed {dup_count} duplicate index rows from Trend Zone data.")
             df_m1_features = engineer_m1_features(df_m1_dt, lag_features_config=lag_config)
             if df_m1_features is None or df_m1_features.empty:
                 logging.critical("(Error) M1 ว่างเปล่าหลัง engineer_m1_features.")


### PR DESCRIPTION
## Summary
- drop duplicate trend index rows in `backtest_engine`
- ensure Trend Zone dataframe has unique index in `src.main`
- test backtest engine duplicate removal
- document change in CHANGELOG

## Testing
- `python3 run_tests.py -k drops_duplicate_trend_index`

------
https://chatgpt.com/codex/tasks/task_e_68490c5f3bb88325a10c4b5953960919