### PR TITLE
[Patch v6.6.3] Sort trend index after dedup in backtest engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1709,3 +1709,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.6.1] Fix M15 trend reindex error by removing duplicates and sorting index
 - Updated tests/test_function_registry.py for new line numbers
 - QA: pytest -q passed (912 tests)
+
+### 2025-07-31
+- [Patch v6.6.3] Ensure Trend Zone index unique and sorted before forward fill
+- New/Updated unit tests added for tests.test_backtest_engine.py::test_run_backtest_engine_sorts_trend_index
+- QA: pytest -q passed (913 tests)

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -70,7 +70,7 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
         except Exception:
             # Fallback: assume NEUTRAL trend for all on error
             trend_df = pd.DataFrame("NEUTRAL", index=features_df.index, columns=["Trend_Zone"])
-        # [Patch v6.6.2] Remove duplicate trend index before alignment
+        # [Patch v6.6.3] Remove duplicate trend indices and sort index before alignment
         if trend_df.index.duplicated().any():
             dup_count = int(trend_df.index.duplicated().sum())
             logging.warning(
@@ -78,10 +78,10 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
             )
             trend_df = trend_df.loc[~trend_df.index.duplicated(keep='first')]
             logging.info(f"      Removed {dup_count} duplicate index rows from Trend Zone data.")
-        # [Patch v6.6.1] Sort trend index for monotonic reindexing
         if not trend_df.index.is_monotonic_increasing:
-            trend_df = trend_df.sort_index(ascending=True)
-        # Align Trend_Zone values to M1 timeline
+            trend_df.sort_index(inplace=True)
+            logging.info("      Sorted Trend Zone DataFrame index in ascending order for alignment")
+        # Align Trend_Zone values to M1 timeline by forward-filling last known trend; default missing to NEUTRAL
         trend_series = trend_df["Trend_Zone"].reindex(features_df.index, method="ffill").fillna("NEUTRAL")
         features_df["Trend_Zone"] = pd.Categorical(trend_series, categories=["NEUTRAL", "UP", "DOWN"])
     else:

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -171,3 +171,28 @@ def test_run_backtest_engine_drops_duplicate_trend_index(monkeypatch, caplog):
 
     assert result.equals(trade_df)
     assert any('duplicate index rows' in msg for msg in caplog.messages)
+
+
+def test_run_backtest_engine_sorts_trend_index(monkeypatch, caplog):
+    m1_df = pd.DataFrame({'Open': [1], 'High': [1], 'Low': [1], 'Close': [1]})
+    m15_df = pd.DataFrame({'Close': [1, 2]}, index=[pd.Timestamp('2024-01-02'), pd.Timestamp('2024-01-01')])
+    trade_df = pd.DataFrame({'pnl': [1.0]})
+
+    def fake_read_csv(path, *a, **k):
+        return m1_df if path == be.DATA_FILE_PATH_M1 else m15_df
+
+    monkeypatch.setattr(be.pd, 'read_csv', fake_read_csv)
+    monkeypatch.setattr(be, 'engineer_m1_features', lambda df, **k: df)
+    monkeypatch.setattr(be, 'calculate_m1_entry_signals', lambda df, cfg: df.assign(Entry_Long=0, Entry_Short=0, Trade_Tag='t', Signal_Score=0.0, Trade_Reason='r'))
+    monkeypatch.setattr(be, 'run_backtest_simulation_v34', lambda df, **k: (None, trade_df))
+
+    def fake_trend(df):
+        return pd.DataFrame({'Trend_Zone': ['UP', 'DOWN']}, index=df.index)
+
+    monkeypatch.setattr(be, 'calculate_m15_trend_zone', fake_trend)
+
+    with caplog.at_level(logging.INFO):
+        result = be.run_backtest_engine(pd.DataFrame())
+
+    assert result.equals(trade_df)
+    assert any('Sorted Trend Zone DataFrame index' in msg for msg in caplog.messages)


### PR DESCRIPTION
## Summary
- ensure trend index deduplicated and sorted before forward-fill
- log sorting action for better diagnostics
- test sorting behavior in backtest engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849169378708325b739a45b0d9fec21