### PR TITLE
Ensure M15 index unique and sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1709,3 +1709,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.6.1] Fix M15 trend reindex error by removing duplicates and sorting index
 - Updated tests/test_function_registry.py for new line numbers
 - QA: pytest -q passed (912 tests)
+
+### 2025-07-31
+- [Patch v6.6.3] Ensure M15 trend index unique and sorted
+- New/Updated unit tests added for tests/test_features_more.py::test_calculate_m15_trend_zone_duplicate_index
+- QA: pytest -q passed (912 tests)

--- a/tests/test_features_more.py
+++ b/tests/test_features_more.py
@@ -115,7 +115,7 @@ def test_calculate_m15_trend_zone_duplicate_index(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         result = features.calculate_m15_trend_zone(df)
 
-    assert len(result) == len(df)
+    assert len(result) == len(df.index.unique())
     logs = " ".join(caplog.messages).lower()
     assert "duplicate labels" in logs
     assert "removed" in logs

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -24,11 +24,11 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "validate_csv_data", 1054),
 
     ("src/features.py", "tag_price_structure_patterns", 473),
-    ("src/features.py", "calculate_trend_zone", 1533),
-    ("src/features.py", "create_session_column", 1540),
-    ("src/features.py", "fill_missing_feature_values", 1546),
-    ("src/features.py", "load_feature_config", 1551),
-    ("src/features.py", "calculate_ml_features", 1556),
+    ("src/features.py", "calculate_trend_zone", 1562),
+    ("src/features.py", "create_session_column", 1569),
+    ("src/features.py", "fill_missing_feature_values", 1575),
+    ("src/features.py", "load_feature_config", 1580),
+    ("src/features.py", "calculate_ml_features", 1585),
 
     ("src/main.py", "parse_arguments", 1915),
     ("src/main.py", "setup_output_directory", 1920),


### PR DESCRIPTION
## Summary
- deduplicate M15 index keeping first and sort ascending before computing Trend Zone
- return cached Trend Zone directly and build result on unique sorted timestamps
- adjust early-return branches for consistent index handling
- update tests for new deduplication behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684916a775ec83258fb329e087454695