### PR TITLE
Fix threshold loading from optuna results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1739,3 +1739,8 @@ QA: pytest -q passed (219 tests)
 
 - QA: pytest -q passed (915 tests)
 
+### 2025-08-04
+- [Patch v6.6.7] Read threshold from 'best_threshold' column
+- Updated tests/test_main_cli_extended.py for new column
+- QA: pytest -q passed (915 tests)
+

--- a/main.py
+++ b/main.py
@@ -140,11 +140,11 @@ def run_backtest(config: PipelineConfig, pipeline_func=run_backtest_pipeline) ->
     if os.path.exists(thresh_path):
         df = pd.read_csv(thresh_path)
         try:
-            threshold_value = df["median"].median()
-            # [Patch v6.5.16] Align threshold reading with ProjectP median logic
+            threshold_value = df["best_threshold"].median()
+            # [Patch v6.6.7] Use Optuna best_threshold directly for backtest
             threshold = float(threshold_value) if not pd.isna(threshold_value) else None
         except KeyError:
-            logging.warning(f"ไม่พบคอลัมน์ 'median' ในไฟล์ {thresh_path}")
+            logging.warning(f"ไม่พบคอลัมน์ 'best_threshold' ในไฟล์ {thresh_path}")
             threshold = None
     try:
         pipeline_func(pd.DataFrame(), pd.DataFrame(), model_path, threshold)

--- a/tests/test_main_cli_extended.py
+++ b/tests/test_main_cli_extended.py
@@ -72,7 +72,7 @@ def test_run_backtest_selects_model_and_threshold(tmp_path):
     cfg = PipelineConfig(model_dir=str(tmp_path), threshold_file='th.csv')
     (tmp_path / 'model_a.joblib').write_text('x')
     (tmp_path / 'model_b.joblib').write_text('x')
-    pd.DataFrame({'median': [0.4, 0.6]}).to_csv(tmp_path / 'th.csv', index=False)
+    pd.DataFrame({'best_threshold': [0.4, 0.6]}).to_csv(tmp_path / 'th.csv', index=False)
     captured = {}
     def fake_pipe(f_df, p_df, model, thresh):
         captured['model'] = model


### PR DESCRIPTION
## Summary
- ใช้คอลัมน์ `best_threshold` จากไฟล์ผล Optuna สำหรับคำนวณค่า threshold
- แก้การทดสอบให้รองรับคอลัมน์ใหม่
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684928a8e2f4832581b98069d911056b