### PR TITLE
[Patch v6.6.7] Fix auto threshold tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 - New/Updated unit tests added for tests/test_backtest_engine.py
 - QA: pytest -q passed (911 tests)
 
+### 2025-07-24
+- [Patch v6.6.7] Fix auto threshold tuning call and threshold reading
+- Updated ProjectP.py to pass supported arguments to `run_threshold_optimization`
+- Updated `main.run_backtest` to handle `best_threshold` column
+- New test `test_run_backtest_best_threshold`
+- QA: pytest -q passed (916 tests)
+
 ### 2025-07-22
 - [Patch v6.5.9] Dynamic threshold + MA fallback for open signals
 - Added new module src/entry_rules.py and corresponding tests

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -513,10 +513,11 @@ if __name__ == "__main__":
             import threshold_optimization as topt
             logger.info("[Patch v6.2.3] Starting Auto Threshold Optimization...")
             topt.run_threshold_optimization(
-                summary_csv=os.path.join(cfg.OUTPUT_DIR, "summary.csv"),
-                output_csv=os.path.join(cfg.OUTPUT_DIR, "threshold_wfv_optuna_results.csv"),
-                cv_splits=getattr(cfg, "OPTUNA_CV_SPLITS", 5),
-                n_trials=getattr(cfg, "OPTUNA_N_TRIALS", 50),
+                output_dir=getattr(cfg, "OUTPUT_DIR", "models"),
+                trials=getattr(cfg, "OPTUNA_N_TRIALS", 50),
+                study_name="threshold_wfv",
+                direction=getattr(cfg, "OPTUNA_DIRECTION", "maximize"),
+                timeout=None,
             )
             logger.info("[Patch v6.2.3] Auto Threshold Optimization Completed.")
 

--- a/tests/test_main_cli_more.py
+++ b/tests/test_main_cli_more.py
@@ -33,3 +33,13 @@ def test_run_backtest_threshold_no_median(tmp_path):
     pipeline.run_backtest(cfg, pipeline_func=lambda *a: captured.update(model=a[2], thresh=a[3]))
     assert captured['model'].endswith('model_1.joblib')
     assert captured['thresh'] is None
+
+
+def test_run_backtest_best_threshold(tmp_path):
+    cfg = PipelineConfig(model_dir=str(tmp_path), threshold_file='th.csv')
+    (tmp_path / 'model_1.joblib').write_text('x')
+    pd.DataFrame({'best_threshold': [0.42]}).to_csv(tmp_path / 'th.csv', index=False)
+    captured = {}
+    pipeline.run_backtest(cfg, pipeline_func=lambda *a: captured.update(model=a[2], thresh=a[3]))
+    assert captured['model'].endswith('model_1.joblib')
+    assert captured['thresh'] == pytest.approx(0.42)


### PR DESCRIPTION
## Summary
- ensure ProjectP passes supported arguments to `run_threshold_optimization`
- read `best_threshold` column in `main.run_backtest`
- test best_threshold reading logic
- document patch

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6849289deda88325ae64b87c7e8effcf