### PR TITLE
[Patch v6.6.9] Use first best_threshold in backtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1771,4 +1771,9 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for tests/test_projectp_cli.py::test_run_backtest_uses_best_threshold
 - QA: pytest -q passed (916 tests)
 
+### 2025-06-11
+- [Patch v6.6.9] Use first best_threshold value when running backtest
+- Updated tests/test_projectp_cli.py::test_run_backtest_uses_best_threshold
+- QA: pytest -q passed (919 tests)
+
 

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -178,7 +178,7 @@ def run_backtest():
     if os.path.exists(thresh_path):
         df = pd.read_csv(thresh_path)
         if "best_threshold" in df.columns:
-            threshold_val = df["best_threshold"].median()
+            threshold_val = df["best_threshold"].iloc[0]
             threshold = float(threshold_val) if not pd.isna(threshold_val) else None
         else:  # pragma: no cover - fallback for legacy column names
             threshold_val = df.median(numeric_only=True).mean()

--- a/tests/test_projectp_cli.py
+++ b/tests/test_projectp_cli.py
@@ -133,5 +133,5 @@ def test_run_backtest_uses_best_threshold(tmp_path, monkeypatch):
 
     proj.run_backtest()
 
-    assert captured['thresh'] == pytest.approx(0.5)
+    assert captured['thresh'] == pytest.approx(0.4)
 


### PR DESCRIPTION
## Summary
- read best threshold from first row of results
- adjust backtest unit test
- update CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492c6c03ac8325aaaa481a59ef78ca