### PR TITLE
Implement fallback logic for minimal training samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1781,3 +1781,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.6.10] Warn when training data missing some features
 - New/Updated unit tests added for tests/test_auto_train_meta_classifiers.py::test_auto_train_meta_classifiers_warns_missing_features
 - QA: pytest -q passed (919 tests)
+
+### 2025-06-13
+- [Patch v6.6.11] Enable fallback_metric when data is insufficient
+- Updated tests/test_training_more.py::test_real_train_func_single_row
+- QA: pytest -q passed (920 tests)

--- a/src/training.py
+++ b/src/training.py
@@ -139,25 +139,30 @@ def real_train_func(
     stratify_arg = y if (len(unique) > 1 and counts.min() >= 2) else None
 
     # [Patch v6.4.7] Require minimum data for training
-    min_samples = 10
-    if len(df_X) < min_samples:
-        raise ValueError(
-            f"Insufficient feature data for training: need >= {min_samples}, got {len(df_X)}"
-        )
-    train_size = max(1, int(len(df_X) * 0.75))
-    test_size = len(df_X) - train_size
-    if test_size == 0:
-        test_size = 1
-        train_size = len(df_X) - 1
-    X_train, X_test, y_train, y_test = train_test_split(
-        df_X,
-        y,
-        train_size=train_size,
-        test_size=test_size,
-        random_state=seed,
-        stratify=stratify_arg,
-    )
+    MIN_SAMPLES = 10
     fallback_metric = False
+    if len(df_X) < MIN_SAMPLES:
+        logger.warning(
+            "พบข้อมูลเพียง %d แถว (<%d) – สลับเป็น fallback_metric + DummyClassifier",
+            len(df_X),
+            MIN_SAMPLES,
+        )
+        fallback_metric = True
+        X_train, X_test, y_train, y_test = df_X, df_X, y, y
+    else:
+        train_size = max(1, int(len(df_X) * 0.75))
+        test_size = len(df_X) - train_size
+        if test_size == 0:
+            test_size = 1
+            train_size = len(df_X) - 1
+        X_train, X_test, y_train, y_test = train_test_split(
+            df_X,
+            y,
+            train_size=train_size,
+            test_size=test_size,
+            random_state=seed,
+            stratify=stratify_arg,
+        )
 
     if CatBoostClassifier and not fallback_metric:
         cat_params = {

--- a/tests/test_training_more.py
+++ b/tests/test_training_more.py
@@ -239,9 +239,10 @@ def test_real_train_func_single_row(tmp_path, monkeypatch, caplog):
         'Close': [1.5]
     }).to_csv(m1_path, index=False)
     monkeypatch.setattr(training, 'CatBoostClassifier', None, raising=False)
-    with pytest.raises(ValueError):
-        training.real_train_func(
+    with caplog.at_level(logging.WARNING, logger=training.logger.name):
+        res = training.real_train_func(
             output_dir=str(tmp_path),
             trade_log_path=str(trade_path),
             m1_path=str(m1_path),
         )
+    assert res['metrics']['accuracy'] == -1.0


### PR DESCRIPTION
## Summary
- enable fallback_metric when training rows < MIN_SAMPLES
- update training test for fallback path
- document new behaviour in CHANGELOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684934d44a108325b894f6daa14e8124