### PR TITLE
[Patch v6.6.12] ข้ามการฝึก meta-classifier เมื่อกำไรเป็นศูนย์

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1787,8 +1787,6 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.6.9] Use first best_threshold value when running backtest
 - Updated tests/test_projectp_cli.py::test_run_backtest_uses_best_threshold
 - QA: pytest -q passed (919 tests)
-
-
 ### 2025-06-12
 - [Patch v6.6.10] Warn when training data missing some features
 - New/Updated unit tests added for tests/test_auto_train_meta_classifiers.py::test_auto_train_meta_classifiers_warns_missing_features
@@ -1802,4 +1800,9 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.6.11] Auto-generate 'target' from profit-like columns
 - New/Updated unit tests added for tests/test_auto_train_meta_classifiers.py::test_auto_train_meta_classifiers_derive_target_alt_column
 - QA: pytest -q passed (919 tests)
+
+### 2025-06-14
+- [Patch v6.6.12] Skip meta-classifier training when all profit values are zero
+- New/Updated unit tests added for tests/test_auto_train_meta_classifiers.py::test_auto_train_meta_classifiers_zero_profit
+- QA: pytest -q passed (924 tests)
 

--- a/src/utils/auto_train_meta_classifiers.py
+++ b/src/utils/auto_train_meta_classifiers.py
@@ -47,6 +47,17 @@ def auto_train_meta_classifiers(
         logger.error("[Patch v6.5.5] Training data must be a DataFrame")
         return None
 
+    # ตรวจสอบคอลัมน์กำไรว่าไม่เป็นศูนย์ทั้งหมด ก่อนเริ่มฝึก
+    profit_col = next(
+        (c for c in ("profit", "pnl_usd_net", "PnL", "pnl") if c in training_data.columns),
+        None,
+    )
+    if profit_col and (training_data[profit_col] == 0).all():
+        logger.error(
+            "[Patch v6.6.12] All profit values are 0 – skipping meta-classifier training"
+        )
+        return None
+
     if features_dir is None:
         features_dir = getattr(config, "OUTPUT_DIR", ".")
     features_path = os.path.join(features_dir, "features_main.json")

--- a/tests/test_auto_train_meta_classifiers.py
+++ b/tests/test_auto_train_meta_classifiers.py
@@ -103,3 +103,16 @@ def test_auto_train_meta_classifiers_warns_missing_features(tmp_path, caplog):
         )
     assert Path(result["model_path"]).exists()
     assert any("missing features" in m for m in caplog.messages)
+
+
+def test_auto_train_meta_classifiers_zero_profit(tmp_path, caplog):
+    """Should skip training when all profit values are zero."""
+    cfg = SimpleNamespace(OUTPUT_DIR=str(tmp_path))
+    (tmp_path / "features_main.json").write_text('["f"]')
+    data = pd.DataFrame({"f": [1, 0, 1, 0, 1], "profit": [0, 0, 0, 0, 0]})
+    with caplog.at_level('ERROR', logger=logger.name):
+        res = auto_train_meta_classifiers(
+            cfg, data, models_dir=str(tmp_path), features_dir=str(tmp_path)
+        )
+    assert res is None
+    assert any("6.6.12" in m and "All profit values are 0" in m for m in caplog.messages)


### PR DESCRIPTION
## Summary
- ปรับ `auto_train_meta_classifiers` ให้หยุดทำงานหากคอลัมน์กำไรมีค่าเป็นศูนย์ทั้งหมด
- เพิ่ม unit test ตรวจสอบกรณีนี้
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494278d7c08325933c6b05a6df6036