### PR TITLE
[Patch v6.7.1] เพิ่มตรวจไฟล์ M1 และหยุดเมื่อไม่มี metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
   tests/test_training_real_dataset.py::test_real_train_func_missing_files
 - QA: pytest -q passed (920 tests)
 
+### 2025-07-26
+- [Patch v6.7.1] Validate M1 path and abort on missing metric
+- New/Updated unit tests added for tests/test_hyperparameter_sweep_cli.py
+- QA: pytest -q passed (923 tests)
+
 ### 2025-07-24
 - [Patch v6.6.11] Intelligent fallback metric in hyperparameter_sweep
 - New/Updated unit tests added for tests/test_hyperparameter_sweep_cli.py::test_run_sweep_fallback_metric


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `_create_placeholder_m1` สร้างไฟล์ M1 ตัวอย่าง
- ใน `run_sweep` ตรวจไฟล์ M1 และสร้าง placeholder หากหาไม่พบ
- เมื่อสรุปผล sweep แล้วไม่มี metric ให้ `SystemExit`
- ปรับ unit test ให้สอดคล้องกับพฤติกรรมใหม่
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849426789f0832581efe1f694af31fb