### PR TITLE
[Patch v6.7.1] จัดการการขาด trade log อย่างปลอดภัย

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-07-26
+- [Patch v6.7.1] Graceful skip when data files missing
+- New/Updated unit tests added for tests/test_training_more.py::test_real_train_func_missing_files tests/test_training_real_dataset.py::test_real_train_func_missing_files
+- QA: pytest -q passed (921 tests)
+
 ### 2025-07-25
 - [Patch v6.7.0] Improve sweep file checks and metric handling
 - New/Updated unit tests added for tests/test_hyperparameter_sweep_cli.py::test_run_sweep_no_metric

--- a/tests/test_training_more.py
+++ b/tests/test_training_more.py
@@ -21,21 +21,13 @@ def test_save_model_none(tmp_path, caplog):
     assert "No model was trained" in caplog.text
 
 
-def test_real_train_func_missing_files(tmp_path):
-    records = []
-    class ListHandler(logging.Handler):
-        def emit(self, record):
-            records.append(record.getMessage())
-
-    handler = ListHandler()
-    training.logger.addHandler(handler)
-    try:
+def test_real_train_func_missing_files(tmp_path, caplog):
+    with caplog.at_level('ERROR', logger=training.logger.name):
         res = training.real_train_func(
             output_dir=str(tmp_path), trade_log_path='no.csv', m1_path='no.csv'
         )
-    finally:
-        training.logger.removeHandler(handler)
     assert res is None
+    assert any('ไม่พบไฟล์ trade log' in m for m in caplog.messages)
 
 
 def test_real_train_func_m1_empty(tmp_path, monkeypatch):

--- a/tests/test_training_real_dataset.py
+++ b/tests/test_training_real_dataset.py
@@ -30,18 +30,10 @@ def test_real_train_func_with_real_data(tmp_path, monkeypatch):
     assert set(res['features']) == {'Open', 'High', 'Low', 'Close'}
 
 
-def test_real_train_func_missing_files(tmp_path):
-    records = []
-    class ListHandler(logging.Handler):
-        def emit(self, record):
-            records.append(record.getMessage())
-
-    handler = ListHandler()
-    training.logger.addHandler(handler)
-    try:
+def test_real_train_func_missing_files(tmp_path, caplog):
+    with caplog.at_level('ERROR', logger=training.logger.name):
         res = training.real_train_func(
             output_dir=str(tmp_path), trade_log_path=None, m1_path=None
         )
-    finally:
-        training.logger.removeHandler(handler)
     assert res is None
+    assert any('ไม่ได้ระบุ trade log หรือ M1 path' in m for m in caplog.messages)


### PR DESCRIPTION
## Summary
- ตรวจสอบการระบุ trade log/M1 path และมีไฟล์อยู่จริงก่อนฝึกโมเดล
- บันทึก error แล้วคืนค่า `None` เมื่อตรวจไม่พบไฟล์
- ปรับปรุงชุดทดสอบให้ยืนยันข้อความ log
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494254cdfc83259254148442e43bfa