### PR TITLE
[Patch v6.7.2] ปรับปรุง real_train_func สำหรับข้อมูลน้อย

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-07-27
+- [Patch v6.7.2] ปรับปรุง real_train_func ให้ข้ามการฝึกโมเดลเมื่อข้อมูลไม่เพียงพอ
+- Updated tests/test_training_more.py::test_real_train_func_single_row
+- QA: pytest -q passed (924 tests)
+
 ### 2025-07-26
 
 - [Patch v6.7.1] Graceful skip when data files missing

--- a/src/training.py
+++ b/src/training.py
@@ -152,29 +152,31 @@ def real_train_func(
 
     # [Patch v6.4.7] Require minimum data for training
     MIN_SAMPLES = 10
-    fallback_metric = False
     if len(df_X) < MIN_SAMPLES:
         logger.warning(
-            "พบข้อมูลเพียง %d แถว (<%d) – สลับเป็น fallback_metric + DummyClassifier",
+            "พบข้อมูลเพียง %d แถว (<%d) – ข้ามการฝึกโมเดลเนื่องจากข้อมูลไม่เพียงพอ",
             len(df_X),
             MIN_SAMPLES,
         )
-        fallback_metric = True
-        X_train, X_test, y_train, y_test = df_X, df_X, y, y
-    else:
-        train_size = max(1, int(len(df_X) * 0.75))
-        test_size = len(df_X) - train_size
-        if test_size == 0:
-            test_size = 1
-            train_size = len(df_X) - 1
-        X_train, X_test, y_train, y_test = train_test_split(
-            df_X,
-            y,
-            train_size=train_size,
-            test_size=test_size,
-            random_state=seed,
-            stratify=stratify_arg,
-        )
+        return {
+            "model_path": {"model": None},
+            "features": feature_names,
+            "metrics": compute_fallback_metrics(df_X),
+        }
+    fallback_metric = False
+    train_size = max(1, int(len(df_X) * 0.75))
+    test_size = len(df_X) - train_size
+    if test_size == 0:
+        test_size = 1
+        train_size = len(df_X) - 1
+    X_train, X_test, y_train, y_test = train_test_split(
+        df_X,
+        y,
+        train_size=train_size,
+        test_size=test_size,
+        random_state=seed,
+        stratify=stratify_arg,
+    )
 
     if CatBoostClassifier and not fallback_metric:
         cat_params = {


### PR DESCRIPTION
## Summary
- skip training in `real_train_func` when dataset has fewer than 10 rows
- avoid using `DummyClassifier` in this case
- update unit test accordingly
- changelog entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494d114bf88325bf6f14d1121a38b0