### PR TITLE
Add output_path option for auto_convert_gold_csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+### 2025-08-04
+- [Patch v6.7.11] Support output_path in auto_convert_gold_csv
+- New/Updated unit tests added for tests/test_auto_convert_csv.py::test_auto_convert_gold_csv_batch
+- QA: pytest -q passed (944 tests)
+
 ### 2025-08-03
 - [Patch v6.7.10] Convert XAUUSD CSV files automatically
 - New/Updated unit tests added for tests/test_auto_convert_csv.py

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Features
 - ระบบมีตัวกรอง ATR และ Median เพื่อช่วยลด Noise ในกรอบเวลา M1
-- ฟังก์ชัน `auto_convert_gold_csv` สำหรับแปลงไฟล์ XAUUSD_M*.csv เป็นปีพุทธศักราช
+- ฟังก์ชัน `auto_convert_gold_csv` สำหรับแปลงไฟล์ XAUUSD_M*.csv เป็นปีพุทธศักราชและบันทึกไปยังเส้นทางที่กำหนด
 
 ## Installation
 ```bash

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ from src.config import DATA_FILE_PATH_M1
 def run_preprocess(config: PipelineConfig, runner=subprocess.run) -> None:
     """Run data preprocessing stage."""
     logger.info("[Stage] preprocess")
-    auto_convert_gold_csv(os.path.dirname(DATA_FILE_PATH_M1))
+    auto_convert_gold_csv(os.path.dirname(DATA_FILE_PATH_M1), output_path=DATA_FILE_PATH_M1)
     try:
         runner([os.environ.get("PYTHON", "python"), "src/data_cleaner.py", DATA_FILE_PATH_M1], check=True)
         runner([os.environ.get("PYTHON", "python"), "ProjectP.py"], check=True)

--- a/tests/test_auto_convert_csv.py
+++ b/tests/test_auto_convert_csv.py
@@ -13,8 +13,8 @@ def test_auto_convert_gold_csv_success(tmp_path):
     })
     csv = tmp_path / 'XAUUSD_M1.csv'
     df.to_csv(csv, index=False)
-    auto_convert_gold_csv(str(tmp_path))
     out_f = tmp_path / 'XAUUSD_M1_thai.csv'
+    auto_convert_gold_csv(str(tmp_path), output_path=str(out_f))
     assert out_f.exists()
     out = pd.read_csv(out_f, dtype=str)
     assert list(out.columns) == ['Date', 'Timestamp', 'Open', 'High', 'Low', 'Close']
@@ -25,5 +25,21 @@ def test_auto_convert_gold_csv_success(tmp_path):
 def test_auto_convert_gold_csv_missing_columns(tmp_path):
     csv = tmp_path / 'XAUUSD_M15.csv'
     pd.DataFrame({'A': [1]}).to_csv(csv, index=False)
-    auto_convert_gold_csv(str(tmp_path))
+    auto_convert_gold_csv(str(tmp_path), output_path=str(tmp_path / 'XAUUSD_M15_thai.csv'))
     assert not (tmp_path / 'XAUUSD_M15_thai.csv').exists()
+
+
+def test_auto_convert_gold_csv_batch(tmp_path):
+    df = pd.DataFrame({
+        'Date': ['2024-01-01'],
+        'Time': ['00:00:00'],
+        'open': [1.0],
+        'high': [1.1],
+        'low': [0.9],
+        'close': [1.0],
+    })
+    for name in ['XAUUSD_M1.csv', 'XAUUSD_M15.csv']:
+        df.to_csv(tmp_path / name, index=False)
+    auto_convert_gold_csv(str(tmp_path), output_path=str(tmp_path))
+    assert (tmp_path / 'XAUUSD_M1_thai.csv').exists()
+    assert (tmp_path / 'XAUUSD_M15_thai.csv').exists()

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -21,7 +21,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m1", 1045),
     ("src/data_loader.py", "load_raw_data_m15", 1055),
     ("src/data_loader.py", "write_test_file", 1059),
-    ("src/data_loader.py", "validate_csv_data", 1117),
+    ("src/data_loader.py", "validate_csv_data", 1141),
 
     ("src/features.py", "tag_price_structure_patterns", 473),
     ("src/features.py", "calculate_trend_zone", 1562),


### PR DESCRIPTION
## Summary
- add optional output_path parameter for `auto_convert_gold_csv`
- log whether converted files are found
- update pipeline to use new path
- expand CSV auto convert tests
- document new capability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b6e4e7a0832584e31d61009bc47c