### PR TITLE
Add debug row limit options for ProjectP pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+### 2025-08-06
+- [Patch v6.7.13] Add debug row limit options to ProjectP CLI
+- QA: pytest -q passed (946 tests)
+
 ### 2025-08-04
 - [Patch v6.7.11] Support output_path in auto_convert_gold_csv
 - New/Updated unit tests added for tests/test_auto_convert_csv.py::test_auto_convert_gold_csv_batch


### PR DESCRIPTION
## Summary
- add `--debug` and `--rows` arguments in `ProjectP.parse_projectp_args`
- when enabled, set `pipeline.sample_size` and `strategy.sample_size` for limited data load
- note debug/full pipeline state clearly
- document change in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c1d47438832592d9167b0d104561