### PR TITLE
[Patch v6.7.15] Fix pandas warnings in backtest engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - New/Updated unit tests added for tests/test_main_cli_extended.py::test_main_debug_sets_sample_size
 - QA: pytest -q passed (954 tests)
 
+### 2025-08-08
+- [Patch v6.7.15] Remove pandas warnings during fallback parsing
+- QA: pytest -q passed (954 tests)
+
 ### 2025-08-06
 - [Patch v6.7.13] Add max_rows option for load_data
 - New/Updated unit tests added for tests/test_data_loader_additional.py::test_load_data_max_rows

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -39,7 +39,7 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
             logging.warning(
                 "(Warning) การ parse วันที่/เวลา ด้วย format ที่กำหนดไม่สำเร็จ - กำลัง parse ใหม่แบบไม่ระบุ format"
             )
-            df.index = pd.to_datetime(combined, errors="coerce")
+            df.index = pd.to_datetime(combined, errors="coerce", format="mixed")
         df.drop(columns=["Date", "Timestamp"], inplace=True)
     elif not isinstance(df.index, pd.DatetimeIndex):
         # fallback: convert existing index
@@ -84,7 +84,7 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
             logging.warning(
                 "(Warning) การ parse วันที่/เวลา (M15) ด้วย format ที่กำหนดไม่สำเร็จ - กำลัง parse ใหม่แบบไม่ระบุ format"
             )
-            df_m15.index = pd.to_datetime(combined, errors="coerce")
+            df_m15.index = pd.to_datetime(combined, errors="coerce", format="mixed")
         df_m15.drop(columns=["Date", "Timestamp"], inplace=True)
     elif df_m15 is not None and not isinstance(df_m15.index, pd.DatetimeIndex):
         df_m15.index = pd.to_datetime(df_m15.index, errors="coerce")


### PR DESCRIPTION
## Summary
- avoid Pandas `Could not infer format` warnings when parsing datetimes
- update CHANGELOG for v6.7.15

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c716dfd8832584dc9eacb0c878e6