### PR TITLE
[Patch v6.7.16] centralize paths in pipeline config

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1,3 +1,8 @@
 log_level: INFO
 model_dir: models
 threshold_file: threshold_wfv_optuna_results.csv
+data:
+  output_dir: "output_default"
+  features_filename: "features_main.json"
+  trade_log_pattern: "trade_log_*.csv*"
+  raw_m1_filename: "XAUUSD_M1.csv"

--- a/main.py
+++ b/main.py
@@ -69,15 +69,16 @@ def parse_args(args=None) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
-from src.config import DATA_FILE_PATH_M1
+
 
 
 def run_preprocess(config: PipelineConfig, runner=subprocess.run) -> None:
     """Run data preprocessing stage."""
     logger.info("[Stage] preprocess")
-    auto_convert_gold_csv(os.path.dirname(DATA_FILE_PATH_M1), output_path=DATA_FILE_PATH_M1)
+    m1_path = config.raw_m1_filename
+    auto_convert_gold_csv(os.path.dirname(m1_path), output_path=m1_path)
     try:
-        runner([os.environ.get("PYTHON", "python"), "src/data_cleaner.py", DATA_FILE_PATH_M1], check=True)
+        runner([os.environ.get("PYTHON", "python"), "src/data_cleaner.py", m1_path], check=True)
         runner([os.environ.get("PYTHON", "python"), "ProjectP.py"], check=True)
     except subprocess.CalledProcessError as exc:
         logger.error("Preprocess failed", exc_info=True)

--- a/src/utils/pipeline_config.py
+++ b/src/utils/pipeline_config.py
@@ -13,6 +13,10 @@ class PipelineConfig:
     log_level: str = 'INFO'
     model_dir: str = 'models'
     threshold_file: str = 'threshold_wfv_optuna_results.csv'
+    output_dir: str = 'output_default'
+    features_filename: str = 'features_main.json'
+    trade_log_pattern: str = 'trade_log_*.csv*'
+    raw_m1_filename: str = 'XAUUSD_M1.csv'
 
 
 def load_config(path: str = DEFAULT_CONFIG_FILE) -> 'PipelineConfig':
@@ -20,5 +24,8 @@ def load_config(path: str = DEFAULT_CONFIG_FILE) -> 'PipelineConfig':
     if os.path.exists(path):
         with open(path, 'r', encoding='utf-8') as fh:
             data = yaml.safe_load(fh) or {}
+        if 'data' in data and isinstance(data['data'], dict):
+            data = {**data, **data['data']}
+            del data['data']
         return PipelineConfig(**{**PipelineConfig().__dict__, **data})
     return PipelineConfig()

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -14,3 +14,15 @@ def test_load_config_override(tmp_path):
     assert cfg.log_level == 'DEBUG'
     assert cfg.model_dir == 'demo'
     assert cfg.threshold_file == 't.csv'
+
+
+def test_load_config_data_section(tmp_path):
+    conf_path = tmp_path / 'cfg.yaml'
+    conf_path.write_text(
+        'data:\n  output_dir: odir\n  features_filename: f.json\n  trade_log_pattern: tl.csv\n  raw_m1_filename: raw.csv\n'
+    )
+    cfg = pipeline_config.load_config(str(conf_path))
+    assert cfg.output_dir == 'odir'
+    assert cfg.features_filename == 'f.json'
+    assert cfg.trade_log_pattern == 'tl.csv'
+    assert cfg.raw_m1_filename == 'raw.csv'


### PR DESCRIPTION
## Summary
- add data section to `config/pipeline.yaml`
- extend `PipelineConfig` with new path attributes
- support nested `data` section when loading config
- update `run_preprocess` to read M1 path from config
- test loading new config fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ca0962cc83259e9c689c6445f608