### PR TITLE
[Patch v6.7.16] Configurable fill_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - [Patch v6.7.15] Remove pandas warnings during fallback parsing
 - QA: pytest -q passed (954 tests)
 
+### 2025-08-09
+- [Patch v6.7.16] Configurable fill_method for preprocessing
+- New/Updated unit tests added for tests/test_pipeline_config.py, tests/test_main_cli_extended.py
+- QA: pytest -q passed (954 tests)
+
 ### 2025-08-06
 - [Patch v6.7.13] Add max_rows option for load_data
 - New/Updated unit tests added for tests/test_data_loader_additional.py::test_load_data_max_rows

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ python ProjectP.py --mode all
 log_level: INFO
 model_dir: models
 threshold_file: threshold_wfv_optuna_results.csv
+cleaning:
+  fill_method: drop
 ```
+ค่า `cleaning.fill_method` สามารถตั้งเป็น `drop` หรือ `mean` เพื่อกำหนดวิธีจัดการค่า NaN
 
 
 

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1,3 +1,5 @@
 log_level: INFO
 model_dir: models
 threshold_file: threshold_wfv_optuna_results.csv
+cleaning:
+  fill_method: "drop"

--- a/main.py
+++ b/main.py
@@ -76,8 +76,16 @@ def run_preprocess(config: PipelineConfig, runner=subprocess.run) -> None:
     """Run data preprocessing stage."""
     logger.info("[Stage] preprocess")
     auto_convert_gold_csv(os.path.dirname(DATA_FILE_PATH_M1), output_path=DATA_FILE_PATH_M1)
+    fill_method = config.cleaning.get('fill_method', 'drop')
+    command = [
+        os.environ.get("PYTHON", "python"),
+        "src/data_cleaner.py",
+        DATA_FILE_PATH_M1,
+        "--fill",
+        fill_method,
+    ]
     try:
-        runner([os.environ.get("PYTHON", "python"), "src/data_cleaner.py", DATA_FILE_PATH_M1], check=True)
+        runner(command, check=True)
         runner([os.environ.get("PYTHON", "python"), "ProjectP.py"], check=True)
     except subprocess.CalledProcessError as exc:
         logger.error("Preprocess failed", exc_info=True)

--- a/src/utils/pipeline_config.py
+++ b/src/utils/pipeline_config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import yaml
 
@@ -13,6 +13,7 @@ class PipelineConfig:
     log_level: str = 'INFO'
     model_dir: str = 'models'
     threshold_file: str = 'threshold_wfv_optuna_results.csv'
+    cleaning: dict = field(default_factory=lambda: {"fill_method": "drop"})
 
 
 def load_config(path: str = DEFAULT_CONFIG_FILE) -> 'PipelineConfig':

--- a/tests/test_main_cli_extended.py
+++ b/tests/test_main_cli_extended.py
@@ -54,7 +54,9 @@ def test_run_preprocess_success():
     called = []
     def fake_run(cmd, check):
         called.append(cmd)
-    pipeline.run_preprocess(PipelineConfig(), runner=fake_run)
+    cfg = PipelineConfig(cleaning={'fill_method': 'mean'})
+    pipeline.run_preprocess(cfg, runner=fake_run)
+    assert called[0][-2:] == ['--fill', 'mean']
     assert any('ProjectP.py' in c[1] for c in called)
 
 

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -5,12 +5,14 @@ def test_load_config_defaults(tmp_path):
     cfg = pipeline_config.load_config(str(tmp_path / 'missing.yaml'))
     assert isinstance(cfg, pipeline_config.PipelineConfig)
     assert cfg.model_dir == 'models'
+    assert cfg.cleaning['fill_method'] == 'drop'
 
 
 def test_load_config_override(tmp_path):
     conf_path = tmp_path / 'cfg.yaml'
-    conf_path.write_text('log_level: DEBUG\nmodel_dir: demo\nthreshold_file: t.csv')
+    conf_path.write_text('log_level: DEBUG\nmodel_dir: demo\nthreshold_file: t.csv\ncleaning:\n  fill_method: mean')
     cfg = pipeline_config.load_config(str(conf_path))
     assert cfg.log_level == 'DEBUG'
     assert cfg.model_dir == 'demo'
     assert cfg.threshold_file == 't.csv'
+    assert cfg.cleaning['fill_method'] == 'mean'


### PR DESCRIPTION
## Summary
- pass fill_method from pipeline.yaml to data_cleaner
- extend PipelineConfig with cleaning options
- document fill_method usage in README
- update tests and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ca38a55c8325aada60578057bb56