### PR TITLE
[Patch v6.7.17] config-driven paths for ProjectP

### DIFF
--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -47,7 +47,7 @@ FUNCTIONS_INFO = [
     ("src/strategy.py", "log_trade", 4614),
     ("src/strategy.py", "aggregate_fold_results", 4617),
 
-    ("ProjectP.py", "custom_helper_function", 95),
+    ("ProjectP.py", "custom_helper_function", 104),
 ]
 
 


### PR DESCRIPTION
## Summary
- load pipeline configuration in `ProjectP.py`
- use config-defined output directory and filenames
- update `test_function_registry` expected line

## Testing
- `pytest tests/test_projectp_fallback.py::test_missing_outputs_creates_dummy -q`
- `python run_tests.py` *(fails: tests/test_projectp_fallback.py::test_missing_outputs_creates_dummy)*

------
https://chatgpt.com/codex/tasks/task_e_6849cc2926a48325a56cd22d713510b2