### PR TITLE
Fix circular import in PipelineManager

### DIFF
--- a/src/pipeline_manager.py
+++ b/src/pipeline_manager.py
@@ -5,8 +5,6 @@ import os
 from .utils.pipeline_config import PipelineConfig
 from .utils.errors import PipelineError
 
-# Import pipeline stage functions from project root main module
-import main as pipeline
 from src.main import ensure_main_features_file
 from src.trade_log_pipeline import load_or_generate_trade_log
 
@@ -31,17 +29,21 @@ class PipelineManager:
         )
 
     def stage_load(self) -> None:
+        import main as pipeline
         pipeline.run_preprocess(self.config)
 
     def stage_sweep(self) -> None:
+        import main as pipeline
         pipeline.run_sweep(self.config)
 
     def stage_wfv(self) -> None:
         # Threshold optimization is part of walk-forward run
+        import main as pipeline
         pipeline.run_threshold(self.config)
         pipeline.run_backtest(self.config)
 
     def stage_save(self) -> None:
+        import main as pipeline
         pipeline.run_report(self.config)
 
     def stage_qa(self) -> None:


### PR DESCRIPTION
## Summary
- resolve circular import by removing global `main` import
- lazily import `main` inside stage methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d3ff8aa483259e8e08c0544d2747