### PR TITLE
Add feature selection and CV to training pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1970,3 +1970,8 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for tests/test_safe_load_csv_limit.py::test_safe_load_csv_auto_duplicate_index
 - QA: pytest -q passed (959 tests)
 
+### 2025-06-12
+- [Patch v6.8.5] Add feature selection step and cross-validation sweep
+- New/Updated unit tests added for src/training.py, tuning/hyperparameter_sweep.py
+- QA: pytest -q passed (tests count TBD)
+

--- a/tests/test_hyperparameter_sweep_cli.py
+++ b/tests/test_hyperparameter_sweep_cli.py
@@ -302,3 +302,26 @@ def test_run_single_trial_skip_on_small_log(monkeypatch, tmp_path, caplog):
     assert 'yes' not in called
 
 
+def test_run_single_trial_with_cv(monkeypatch, tmp_path):
+    df_log = pd.DataFrame({'profit': [1, -1] * 5})
+    m1_path = tmp_path / 'm1.csv'
+    pd.DataFrame({
+        'Open': range(10),
+        'High': range(10),
+        'Low': range(10),
+        'Close': range(10)
+    }).to_csv(m1_path, index=False)
+
+    def dummy_train(**kwargs):
+        return {
+            'model_path': {'model': str(tmp_path / 'm.joblib')},
+            'features': ['Open'],
+            'metrics': {'accuracy': 1.0}
+        }
+
+    monkeypatch.setattr(hs, 'real_train_func', dummy_train)
+
+    res = hs._run_single_trial({}, df_log, str(tmp_path), str(tmp_path/'log.csv'), str(m1_path))
+    assert 'cv_auc' in res['metrics']
+
+


### PR DESCRIPTION
## Summary
- add simple ANOVA-based feature selection helper
- use optional feature selection in `real_train_func`
- add cross-validation evaluation in hyperparameter sweep
- test feature selection and CV logic

## Testing
- `python run_tests.py --fast`

------
https://chatgpt.com/codex/tasks/task_e_684a32a98e708325b5852a7e92912395