### PR TITLE
Add helper to load project CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2014,3 +2014,7 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.8.9] Enforce CSV validation using project columns
 - New/Updated unit tests added for tests/test_csv_validator.py::test_validate_and_convert_csv_success
 - QA: pytest -q passed (971 tests)
+### 2025-06-12
+- [Patch v6.8.10] Add helper to load default project CSV files
+- New/Updated unit tests added for tests/test_load_project_csvs.py
+- QA: pytest -q passed (tests count TBD)

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1248,6 +1248,27 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
             print(f"✔ [AutoConvert] {out_f} OK - {status}ไฟล์")
         except Exception as e:
             print(f"✗ [AutoConvert] Error ({f}): {e}")
+
+# [Patch v6.8.10] Helper to load default project CSV files
+def load_project_csvs(row_limit=None):
+    """Load XAUUSD_M1.csv และ XAUUSD_M15.csv ที่อยู่ในรูทโปรเจค
+
+    Parameters
+    ----------
+    row_limit : int, optional
+        จำกัดจำนวนแถวที่โหลดเพื่อให้การทดสอบทำงานรวดเร็ว
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        ข้อมูลจากไฟล์ M1 และ M15 ตามลำดับ
+    """
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    m1_path = os.path.join(base_dir, "XAUUSD_M1.csv")
+    m15_path = os.path.join(base_dir, "XAUUSD_M15.csv")
+    m1_df = safe_load_csv_auto(m1_path, row_limit=row_limit)
+    m15_df = safe_load_csv_auto(m15_path, row_limit=row_limit)
+    return m1_df, m15_df
 # [Patch v5.7.3] Validate DataFrame for required columns and non-emptiness
 def validate_csv_data(df, required_cols=None):
     """Ensure ``df`` is non-empty and contains required columns.
@@ -1378,5 +1399,6 @@ __all__ = [
     "load_final_m1_data",
     "check_data_quality",
     "auto_convert_gold_csv",
+    "load_project_csvs",
 ]
 

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -22,7 +22,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m1", 1155),
     ("src/data_loader.py", "load_raw_data_m15", 1165),
     ("src/data_loader.py", "write_test_file", 1171),
-    ("src/data_loader.py", "validate_csv_data", 1252),
+    ("src/data_loader.py", "validate_csv_data", 1273),
 
 
     ("src/features.py", "tag_price_structure_patterns", 473),

--- a/tests/test_load_project_csvs.py
+++ b/tests/test_load_project_csvs.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from src.data_loader import load_project_csvs
+
+def test_load_project_csvs():
+    m1, m15 = load_project_csvs(row_limit=5)
+    assert isinstance(m1, pd.DataFrame)
+    assert isinstance(m15, pd.DataFrame)
+    assert not m1.empty
+    assert not m15.empty
+    for col in ["Open", "High", "Low", "Close"]:
+        assert col.lower() in m1.columns or col in m1.columns
+        assert col.lower() in m15.columns or col in m15.columns


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `load_project_csvs` ใน `src/data_loader.py` สำหรับโหลดไฟล์ XAUUSD_M1.csv และ XAUUSD_M15.csv จากรูทโปรเจค
- ทดสอบ `load_project_csvs` ให้โหลดข้อมูลได้ถูกต้อง
- ปรับเลขบรรทัดที่คาดหวังใน `test_function_registry`
- บันทึกการเปลี่ยนแปลงใน CHANGELOG

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684a5004bf1c83258f5058c364aafd2d