### PR TITLE
Fix session tagging and M15 dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2036,3 +2036,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.8.12] Validate M1 CSV path in profile_backtest.main_profile
 - New/Updated unit tests added for profile_backtest
 - QA: pytest -q passed (974 tests)
+
+### 2025-06-13
+- [Patch v6.8.13] Fix session tagging and M15 duplicate handling
+- New/Updated unit tests added for tests/test_features_stub_functions.py and tests/test_backtest_engine.py
+- QA: pytest -q passed (975 tests)

--- a/tests/test_features_stub_functions.py
+++ b/tests/test_features_stub_functions.py
@@ -18,11 +18,13 @@ def test_calculate_trend_zone_returns_neutral_series():
     assert result.tolist() == ['NEUTRAL'] * 3
 
 
-def test_create_session_column_adds_other():
-    df = pd.DataFrame({'Open': [1]})
+def test_create_session_column_tags_sessions():
+    idx = pd.date_range('2024-01-01 00:00', periods=3, freq='6h')
+    df = pd.DataFrame({'Open': [1, 2, 3]}, index=idx)
     result = features.create_session_column(df.copy())
+    expected = [features.get_session_tag(ts) for ts in idx]
     assert 'session' in result.columns
-    assert (result['session'] == 'Other').all()
+    assert result['session'].tolist() == expected
 
 
 def test_fill_missing_feature_values_replaces_nan():

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -27,10 +27,10 @@ FUNCTIONS_INFO = [
 
     ("src/features.py", "tag_price_structure_patterns", 473),
     ("src/features.py", "calculate_trend_zone", 1572),
-    ("src/features.py", "create_session_column", 1579),
-    ("src/features.py", "fill_missing_feature_values", 1585),
-    ("src/features.py", "load_feature_config", 1590),
-    ("src/features.py", "calculate_ml_features", 1595),
+    ("src/features.py", "create_session_column", 1583),
+    ("src/features.py", "fill_missing_feature_values", 1609),
+    ("src/features.py", "load_feature_config", 1614),
+    ("src/features.py", "calculate_ml_features", 1619),
 
     ("src/main.py", "parse_arguments", 2005),
     ("src/main.py", "setup_output_directory", 2010),


### PR DESCRIPTION
## Summary
- handle session tagging via `get_session_tag`
- drop duplicate M15 rows in `run_backtest_engine`
- update unit tests for new session logic
- document patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a66af0bd483258f1c03ad1d27fa0e