### PR TITLE
แก้ session column และเพิ่มการทดสอบ

### DIFF
--- a/src/features.py
+++ b/src/features.py
@@ -1591,7 +1591,10 @@ def create_session_column(df):
     """
 
     # [Patch v6.8.13] Proper session tagging implementation
-    if df is None or df.empty:
+    if df is None:
+        logging.warning("create_session_column received None, returning empty DataFrame")
+        return pd.DataFrame({"session": pd.Categorical([], categories=["Asia", "London", "NY", "Other", "N/A"])} )
+    if df.empty:
         df["session"] = pd.Categorical([], categories=["Asia", "London", "NY", "Other", "N/A"])
         return df
 

--- a/tests/test_features_stub_functions.py
+++ b/tests/test_features_stub_functions.py
@@ -27,6 +27,20 @@ def test_create_session_column_tags_sessions():
     assert result['session'].tolist() == expected
 
 
+def test_create_session_column_handles_none():
+    result = features.create_session_column(None)
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert 'session' in result.columns
+
+
+def test_create_session_column_handles_empty_df():
+    df = pd.DataFrame({'Open': []})
+    result = features.create_session_column(df)
+    assert 'session' in result.columns
+    assert result.empty
+
+
 def test_fill_missing_feature_values_replaces_nan():
     df = pd.DataFrame({'A': [1.0, np.nan]})
     result = features.fill_missing_feature_values(df)


### PR DESCRIPTION
## Summary
- improve `create_session_column` to handle `None` and empty frames
- add tests for these edge cases
- verify `ta` library installed

## Testing
- `pytest tests/test_features_stub_functions.py::test_create_session_column_handles_none -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6d139a848325a34882c0effc9b73