### PR TITLE
Optimize Thai date parsing in data_loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2051,3 +2051,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.8.15] Improve safe_load_csv_auto datetime parsing and duplicate handling
 - New/Updated unit tests added for tests/test_function_registry.py
 - QA: pytest -q passed (979 tests)
+
+### 2025-06-16
+- [Patch v6.8.16] Optimize Thai date parsing with vectorized logic
+- New/Updated unit tests added for tests/test_parse_thai_date_fast.py
+- QA: pytest -q passed (981 tests)

--- a/tests/test_parse_thai_date_fast.py
+++ b/tests/test_parse_thai_date_fast.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import src.data_loader as dl
+
+
+def test_parse_thai_date_fast_basic():
+    s = pd.Series(['24/1/2567', '1/12/2566'])
+    result = dl._parse_thai_date_fast(s)
+    assert result.iloc[0] == pd.Timestamp('2024-01-24')
+    assert result.iloc[1] == pd.Timestamp('2023-12-01')
+
+
+def test_parse_thai_date_fast_invalid():
+    s = pd.Series(['invalid', '31/13/2567'])
+    result = dl._parse_thai_date_fast(s)
+    assert result.isna().all()


### PR DESCRIPTION
## Summary
- improve Thai date parsing performance with `_parse_thai_date_fast`
- apply new parser in `safe_load_csv_auto`
- add tests for the fast parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8717d9e48325ac750c9a6aedee45