### PR TITLE
Add index validation and update tests

### DIFF
--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -42,12 +42,12 @@ FUNCTIONS_INFO = [
     ("src/main.py", "run_auto_threshold_stage", 2041),
 
     ("src/strategy.py", "run_backtest_simulation_v34", 1941),
-    ("src/strategy.py", "calculate_metrics", 3233),
-    ("src/strategy.py", "initialize_time_series_split", 4605),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4608),
-    ("src/strategy.py", "apply_kill_switch", 4611),
-    ("src/strategy.py", "log_trade", 4614),
-    ("src/strategy.py", "aggregate_fold_results", 4617),
+    ("src/strategy.py", "calculate_metrics", 3241),
+    ("src/strategy.py", "initialize_time_series_split", 4613),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4616),
+    ("src/strategy.py", "apply_kill_switch", 4619),
+    ("src/strategy.py", "log_trade", 4622),
+    ("src/strategy.py", "aggregate_fold_results", 4625),
 
     ("ProjectP.py", "custom_helper_function", 104),
 ]


### PR DESCRIPTION
## Summary
- ensure DatetimeIndex before running backtest
- iterate over dataframe using index
- test invalid index handling
- update expected line numbers for function registry tests

## Testing
- `pytest tests/test_simulation.py tests/test_function_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684a8e093f2c8325ac14ba7d96960f3a