### PR TITLE
Fix prepare_datetime_index to use Timestamp

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1149,8 +1149,8 @@ def convert_thai_datetime(series, tz="UTC", errors="raise"):
 
 def prepare_datetime_index(df):
     """Stubbed datetime index preparer."""
-    if 'Date' in df.columns:
-        df.index = pd.to_datetime(df['Date'], errors='coerce')
+    if 'Timestamp' in df.columns:
+        df.index = pd.to_datetime(df['Timestamp'], errors='coerce')
     return df
 
 

--- a/tests/test_loader_main_functions.py
+++ b/tests/test_loader_main_functions.py
@@ -56,7 +56,7 @@ def test_convert_thai_datetime_invalid():
 
 
 def test_prepare_datetime_index_sets_index():
-    df = pd.DataFrame({'Date': ['2024-01-01']})
+    df = pd.DataFrame({'Timestamp': ['2024-01-01']})
     res = dl.prepare_datetime_index(df.copy())
     assert isinstance(res.index, pd.DatetimeIndex)
 


### PR DESCRIPTION
## Summary
- adjust `prepare_datetime_index` to use `Timestamp` column
- update related unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6a3a2a208325a16a2d236299b6b5