### PR TITLE
[Patch v6.9.4] fix datetime index rename

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1148,7 +1148,9 @@ def convert_thai_datetime(series, tz="UTC", errors="raise"):
 
 
 def prepare_datetime_index(df):
-    """Stubbed datetime index preparer."""
+    """Set a DatetimeIndex using a 'Timestamp' column."""
+    if 'Timestamp' not in df.columns and 'Date' in df.columns:
+        df = df.rename(columns={'Date': 'Timestamp'})
     if 'Timestamp' in df.columns:
         df.index = pd.to_datetime(df['Timestamp'], errors='coerce')
     return df

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -19,10 +19,10 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "convert_thai_years", 1110),
     ("src/data_loader.py", "convert_thai_datetime", 1117),
     ("src/data_loader.py", "prepare_datetime_index", 1145),
-    ("src/data_loader.py", "load_raw_data_m1", 1200),
-    ("src/data_loader.py", "load_raw_data_m15", 1210),
-    ("src/data_loader.py", "write_test_file", 1216),
-    ("src/data_loader.py", "validate_csv_data", 1318),
+    ("src/data_loader.py", "load_raw_data_m1", 1207),
+    ("src/data_loader.py", "load_raw_data_m15", 1217),
+    ("src/data_loader.py", "write_test_file", 1223),
+    ("src/data_loader.py", "validate_csv_data", 1325),
 
 
     ("src/features.py", "tag_price_structure_patterns", 473),

--- a/tests/unit/test_data_loader_full.py
+++ b/tests/unit/test_data_loader_full.py
@@ -120,6 +120,13 @@ def test_prepare_datetime_index_no_date():
     assert res.index.equals(df.index)
 
 
+def test_prepare_datetime_index_rename_date():
+    df = pd.DataFrame({'Date': ['2024-01-01']})
+    res = dl.prepare_datetime_index(df.copy())
+    assert isinstance(res.index, pd.DatetimeIndex)
+    assert 'Timestamp' in res.columns
+
+
 def test_load_raw_data_m1_invalid(monkeypatch):
     monkeypatch.setattr(dl, 'validate_m1_data_path', lambda p: False)
     assert dl.load_raw_data_m1('bad') is None


### PR DESCRIPTION
## Summary
- allow `prepare_datetime_index` to rename `Date` column to `Timestamp`
- update unit tests for the new behavior
- adjust line number expectations in test_function_registry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6cb50db883258c7d4e806c4a2227