### PR TITLE
Improve datetime auto detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-06-17
+- [Patch v6.9.4] Auto-detect datetime column names
+- New/Updated unit tests added for src/feature_analysis.py
+- QA: pytest -q passed (980 tests)
+
 ### 2025-06-13
 - [Patch v6.9.3] Restore backtest logic
 - QA: pytest -q passed (977 tests, 7 skipped)

--- a/tests/test_feature_analysis.py
+++ b/tests/test_feature_analysis.py
@@ -128,3 +128,20 @@ def test_feature_analysis_main_missing_date(monkeypatch, tmp_path, caplog):
     assert low_var == []
     assert corr.empty
     assert "Missing Date/Timestamp columns" in caplog.text
+
+
+def test_feature_analysis_main_autodetect(monkeypatch, tmp_path):
+    """Ensure main detects various datetime column names"""
+    monkeypatch.chdir(tmp_path)
+    df = pd.DataFrame({
+        "Date/Time": ["2024-01-01 00:00:00"],
+        "Open": [1],
+        "High": [1],
+        "Low": [1],
+        "Close": [1],
+    })
+    monkeypatch.setattr(pd, "read_csv", lambda *a, **k: df)
+    stats, low_var, corr = feature_analysis.main(sample_rows=1)
+    assert isinstance(stats, dict)
+    assert isinstance(low_var, list)
+    assert isinstance(corr, pd.DataFrame)


### PR DESCRIPTION
## Summary
- auto-detect datetime column names in feature analysis
- generalize datetime parsing in backtest_engine
- enhance Thai CSV conversion to find common time columns
- update test for feature analysis to cover new logic
- document patch in CHANGELOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b8e60444c83259cdb62427996da44