### PR TITLE
[Patch v6.9.5] Handle invalid dates in auto_convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for src/feature_analysis.py
 - QA: pytest -q passed (980 tests)
 
+### 2025-06-18
+- [Patch v6.9.5] Handle invalid dates in auto_convert
+- New/Updated unit tests added for tests/test_auto_convert_csv.py, tests/test_function_registry.py
+- QA: pytest -q passed (981 tests)
+
 ### 2025-06-13
 - [Patch v6.9.3] Restore backtest logic
 - QA: pytest -q passed (977 tests, 7 skipped)

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1303,8 +1303,14 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
                     print(f"ข้าม {f}: ไม่พบคอลัมน์ Date/Time")
                     continue
                 dt = pd.to_datetime(df[time_col], errors="coerce")
-            df["Date"] = dt.map(lambda d: f"{d.year + 543:04d}{d.month:02d}{d.day:02d}")
-            df["Timestamp"] = dt.dt.strftime("%H:%M:%S")
+            # [Patch v6.9.5] Handle unparsable dates gracefully
+            def to_thai_date(d):
+                if pd.isna(d):
+                    return np.nan
+                return f"{int(d.year) + 543:04d}{int(d.month):02d}{int(d.day):02d}"
+
+            df["Date"] = dt.map(to_thai_date)
+            df["Timestamp"] = dt.dt.strftime("%H:%M:%S").fillna("")
             for col in ["Open", "High", "Low", "Close"]:
                 if col not in df.columns and col.lower() in df.columns:
                     df[col] = df[col.lower()]

--- a/tests/test_auto_convert_csv.py
+++ b/tests/test_auto_convert_csv.py
@@ -43,3 +43,20 @@ def test_auto_convert_gold_csv_batch(tmp_path):
     auto_convert_gold_csv(str(tmp_path), output_path=str(tmp_path))
     assert (tmp_path / 'XAUUSD_M1_thai.csv').exists()
     assert (tmp_path / 'XAUUSD_M15_thai.csv').exists()
+
+
+def test_auto_convert_gold_csv_invalid_date(tmp_path):
+    df = pd.DataFrame({
+        'Date': ['bad'],
+        'Time': ['00:00:00'],
+        'Open': [1.0],
+        'High': [1.1],
+        'Low': [0.9],
+        'Close': [1.0],
+    })
+    csv = tmp_path / 'XAUUSD_M1.csv'
+    df.to_csv(csv, index=False)
+    out_f = tmp_path / 'XAUUSD_M1_thai.csv'
+    auto_convert_gold_csv(str(tmp_path), output_path=str(out_f))
+    out = pd.read_csv(out_f)
+    assert pd.isna(out.iloc[0]['Date'])

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -22,7 +22,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m1", 1217),
     ("src/data_loader.py", "load_raw_data_m15", 1227),
     ("src/data_loader.py", "write_test_file", 1233),
-    ("src/data_loader.py", "validate_csv_data", 1335),
+    ("src/data_loader.py", "validate_csv_data", 1345),
 
 
     ("src/features.py", "tag_price_structure_patterns", 473),


### PR DESCRIPTION
## Summary
- handle unparsable timestamps when converting CSV to Thai datetime
- add regression test for invalid dates
- adjust function registry line numbers
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b931d88548325a03efeb61e5c3a86