### PR TITLE
Fix pandas warnings

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -116,7 +116,11 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
     else:
         time_col = next((c for c in df.columns if c in possible_cols), None)
         if time_col:
-            df.index = pd.to_datetime(df[time_col], errors="coerce")
+            df.index = pd.to_datetime(
+                df[time_col],
+                errors="coerce",
+                format="%Y-%m-%d %H:%M:%S",
+            )
             df.drop(columns=[time_col], inplace=True, errors="ignore")
         elif not isinstance(df.index, pd.DatetimeIndex):
             df.index = pd.to_datetime(df.index, errors="coerce")

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1296,13 +1296,22 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
             df.columns = [c.capitalize() for c in df.columns]
             possible_cols = ["Date", "Date/Time", "Timestamp", "Datetime", "Time"]
             if {"Date", "Time"}.issubset(df.columns):
-                dt = pd.to_datetime(df["Date"] + " " + df["Time"], errors="coerce")
+                # "YYYY-MM-DD" + "HH:MM:SS" -> specify format to avoid warnings
+                dt = pd.to_datetime(
+                    df["Date"] + " " + df["Time"],
+                    format="%Y-%m-%d %H:%M:%S",
+                    errors="coerce",
+                )
             else:
                 time_col = next((c for c in df.columns if c in possible_cols), None)
                 if time_col is None:
                     print(f"ข้าม {f}: ไม่พบคอลัมน์ Date/Time")
                     continue
-                dt = pd.to_datetime(df[time_col], errors="coerce")
+                dt = pd.to_datetime(
+                    df[time_col],
+                    format="%Y-%m-%d %H:%M:%S",
+                    errors="coerce",
+                )
             # [Patch v6.9.5] Handle unparsable dates gracefully
             def to_thai_date(d):
                 if pd.isna(d):

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -22,7 +22,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m1", 1217),
     ("src/data_loader.py", "load_raw_data_m15", 1227),
     ("src/data_loader.py", "write_test_file", 1233),
-    ("src/data_loader.py", "validate_csv_data", 1345),
+    ("src/data_loader.py", "validate_csv_data", 1354),
 
 
     ("src/features.py", "tag_price_structure_patterns", 473),


### PR DESCRIPTION
## Summary
- specify datetime formats in `auto_convert_gold_csv`
- parse timestamps with explicit format in `backtest_engine`
- update expected line number in `test_function_registry`

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684b976574448325aac0280cf7a3bae2