### PR TITLE
Fix pandas datetime warnings

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -116,10 +116,10 @@ def run_backtest_engine(features_df: pd.DataFrame) -> pd.DataFrame:
     else:
         time_col = next((c for c in df.columns if c in possible_cols), None)
         if time_col:
-            df.index = pd.to_datetime(df[time_col], errors="coerce")
+            df.index = pd.to_datetime(df[time_col], errors="coerce", format="mixed")
             df.drop(columns=[time_col], inplace=True, errors="ignore")
         elif not isinstance(df.index, pd.DatetimeIndex):
-            df.index = pd.to_datetime(df.index, errors="coerce")
+            df.index = pd.to_datetime(df.index, errors="coerce", format="mixed")
 
     # 1b) Ensure index is a DatetimeIndex so `.tz` attribute exists
     if not isinstance(df.index, pd.DatetimeIndex):

--- a/src/feature_analysis.py
+++ b/src/feature_analysis.py
@@ -226,7 +226,7 @@ def main(sample_rows: int = 5000):  # pragma: no cover - CLI helper
         if time_col is None:
             logger.error("Missing Date/Timestamp columns in dataset")
             return {}, [], pd.DataFrame()
-        df[time_col] = pd.to_datetime(df[time_col], errors="coerce")
+        df[time_col] = pd.to_datetime(df[time_col], errors="coerce", format="mixed")
         df.index = df[time_col]
     df_feat = feat.engineer_m1_features(df)
 

--- a/src/features.py
+++ b/src/features.py
@@ -722,7 +722,7 @@ def engineer_m1_features(df_m1, timeframe_minutes=TIMEFRAME_MINUTES_M1, lag_feat
         logging.info("      Creating 'session' column...")
         try:
             if not isinstance(df.index, pd.DatetimeIndex):
-                df.index = pd.to_datetime(df.index, errors='coerce')
+                df.index = pd.to_datetime(df.index, errors='coerce', format='mixed')
             sessions = pd.Index(df.index).map(lambda ts: get_session_tag(ts, warn_once=True))
             df['session'] = pd.Series(sessions, index=df.index).astype('category')
             logging.info(
@@ -1600,7 +1600,7 @@ def create_session_column(df):
 
     try:
         if not isinstance(df.index, pd.DatetimeIndex):
-            df.index = pd.to_datetime(df.index, errors="coerce")
+            df.index = pd.to_datetime(df.index, errors="coerce", format="mixed")
         sessions = pd.Index(df.index).map(lambda ts: get_session_tag(ts, warn_once=True))
         df["session"] = pd.Categorical(sessions, categories=["Asia", "London", "NY", "Other", "N/A"])
     except Exception as e:

--- a/src/utils/data_utils.py
+++ b/src/utils/data_utils.py
@@ -14,7 +14,7 @@ def convert_thai_datetime(df: pd.DataFrame, column: str) -> pd.DataFrame:
         series = pd.to_datetime(df[column], errors="raise")
     except Exception as e:
         logger.error("convert_thai_datetime failed: %s", e, exc_info=True)
-        series = pd.to_datetime(df[column], errors="coerce")
+        series = pd.to_datetime(df[column], errors="coerce", format="mixed")
     df[column] = series
     return df
 


### PR DESCRIPTION
## Summary
- use `format='mixed'` when parsing datetime columns
- update feature utilities to avoid pandas warnings

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684b9aba90148325b6d274f2d07f5b31