### PR TITLE
Add M1 CSV path to settings

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -5,3 +5,4 @@ feature_format: parquet
 data:
   data_dir: 'data'
   parquet_dir: 'data/parquet_cache'
+  path: 'data/XAUUSD_M1.csv'


### PR DESCRIPTION
## Summary
- specify default CSV path in `settings.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc367299483258a22590031e697b5