### PR TITLE
Implement Thai date handling in CSV loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# ### 2025-06-27
+- [Patch v6.9.12] Handle Thai dates in load_data_from_csv
+- New/Updated unit tests added for tests/test_load_data_from_csv.py, tests/test_data_utils_new.py
+- QA: pytest -q passed (tests count TBD)
+
 # ### 2025-06-26
 
 - [Patch v6.9.11] Clarify directory fallback comment in auto_convert_gold_csv

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -21,7 +21,7 @@ from src.utils.model_utils import (
 )
 from src.utils.env_utils import get_env_float
 from src.utils.gc_utils import maybe_collect
-from src.utils.data_utils import convert_thai_datetime, prepare_csv_auto
+from src.utils.data_utils import convert_thai_datetime, prepare_csv_auto, parse_thai_date_fast
 from src.utils.resource_plan import get_resource_plan, save_resource_plan
 from src.utils.hardware import estimate_resource_plan
 from src.utils.json_utils import load_json_with_comments
@@ -47,6 +47,7 @@ __all__ = [
     "maybe_collect",
     "convert_thai_datetime",
     "prepare_csv_auto",
+    "parse_thai_date_fast",
     "estimate_resource_plan",
     "get_resource_plan",
     "save_resource_plan",

--- a/tests/test_data_utils_new.py
+++ b/tests/test_data_utils_new.py
@@ -6,7 +6,7 @@ import logging
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, ROOT_DIR)
 
-from src.utils.data_utils import convert_thai_datetime, prepare_csv_auto
+from src.utils.data_utils import convert_thai_datetime, prepare_csv_auto, parse_thai_date_fast
 
 
 def test_convert_thai_datetime_invalid(caplog):
@@ -24,3 +24,16 @@ def test_prepare_csv_auto_missing_timestamp(tmp_path, caplog):
         df = prepare_csv_auto(str(csv_path))
     assert 'timestamp column missing' in caplog.text
     assert 'a' in df.columns
+
+
+def test_parse_thai_date_fast_basic_utils():
+    s = pd.Series(['24/1/2567', '1/12/2566'])
+    result = parse_thai_date_fast(s)
+    assert result.iloc[0] == pd.Timestamp('2024-01-24')
+    assert result.iloc[1] == pd.Timestamp('2023-12-01')
+
+
+def test_parse_thai_date_fast_invalid_utils():
+    s = pd.Series(['invalid', '31/13/2567'])
+    result = parse_thai_date_fast(s)
+    assert result.isna().all()

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -22,7 +22,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m1", 1217),
     ("src/data_loader.py", "load_raw_data_m15", 1227),
     ("src/data_loader.py", "write_test_file", 1233),
-    ("src/data_loader.py", "validate_csv_data", 1395),
+    ("src/data_loader.py", "validate_csv_data", 1445),
 
 
     ("src/features.py", "tag_price_structure_patterns", 473),

--- a/tests/test_load_data_from_csv.py
+++ b/tests/test_load_data_from_csv.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import pytest
+from src.data_loader import load_data_from_csv
+
+
+def test_load_data_from_csv_thai_year(tmp_path):
+    df = pd.DataFrame({
+        'Time': ['1/1/2567 00:00:00'],
+        'Open': [1.0],
+        'High': [1.0],
+        'Low': [1.0],
+        'Close': [1.0],
+        'Volume': [1.0],
+    })
+    p = tmp_path / 'thai.csv'
+    df.to_csv(p, index=False)
+    result = load_data_from_csv(str(p))
+    assert result.index[0] == pd.Timestamp('2024-01-01 00:00:00')
+    assert list(result.columns) == ['Open', 'High', 'Low', 'Close', 'Volume']
+
+
+def test_load_data_from_csv_timestamp(tmp_path):
+    df = pd.DataFrame({
+        'Timestamp': ['2024-01-02 00:00:00'],
+        'Open': [1],
+        'High': [1],
+        'Low': [1],
+        'Close': [1],
+        'Volume': [1],
+    })
+    p = tmp_path / 'ts.csv'
+    df.to_csv(p, index=False)
+    res = load_data_from_csv(str(p))
+    assert res.index[0] == pd.Timestamp('2024-01-02 00:00:00')
+    assert isinstance(res.index, pd.DatetimeIndex)
+
+
+def test_load_data_from_csv_missing_cols(tmp_path):
+    df = pd.DataFrame({'Time': ['2024-01-01']})
+    p = tmp_path / 'bad.csv'
+    df.to_csv(p, index=False)
+    with pytest.raises(ValueError):
+        load_data_from_csv(str(p))


### PR DESCRIPTION
## Summary
- add `parse_thai_date_fast` helper to `data_utils`
- use the helper in new `load_data_from_csv`
- export the new helper from `utils`
- update CHANGELOG and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd9d8789083259ee9e6caa98dce60