### PR TITLE
Fix CSV Timestamp handling in Thai conversion

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1323,17 +1323,19 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
                 dt = pd.to_datetime(
                     df["Date"].astype(str) + " " + df["Time"].astype(str), errors="coerce"
                 )
-
-                def format_thai_date(d):
-                    if pd.isna(d):
-                        return None
-                    return f"{d.year + 543:04d}{d.month:02d}{d.day:02d}"
-
-                df["Date"] = dt.map(format_thai_date)
-                df["Timestamp"] = dt.dt.strftime("%H:%M:%S")
+            elif "Timestamp" in df.columns:
+                dt = pd.to_datetime(df["Timestamp"].astype(str), errors="coerce")
             else:
                 print(f"ข้าม {f}: ไม่พบคอลัมน์ Date/Time")
                 continue
+
+            def format_thai_date(d):
+                if pd.isna(d):
+                    return None
+                return f"{d.year + 543:04d}{d.month:02d}{d.day:02d}"
+
+            df["Date"] = dt.map(format_thai_date)
+            df["Timestamp"] = dt.dt.strftime("%H:%M:%S")
 
             for col in ["Open", "High", "Low", "Close"]:
                 if col not in df.columns and col.lower() in df.columns:

--- a/tests/test_auto_convert_csv.py
+++ b/tests/test_auto_convert_csv.py
@@ -78,6 +78,24 @@ def test_auto_convert_gold_csv_empty_dir(monkeypatch, tmp_path):
     assert (tmp_path / 'XAUUSD_M1_thai.csv').exists()
 
 
+def test_auto_convert_gold_csv_timestamp_only(tmp_path):
+    df = pd.DataFrame({
+        'Timestamp': ['2024-01-01 00:00:00'],
+        'Open': [1.0],
+        'High': [1.1],
+        'Low': [0.9],
+        'Close': [1.0],
+    })
+    csv = tmp_path / 'XAUUSD_M15.csv'
+    df.to_csv(csv, index=False)
+    out_f = tmp_path / 'XAUUSD_M15_thai.csv'
+    auto_convert_gold_csv(str(tmp_path), output_path=str(out_f))
+    assert out_f.exists()
+    out = pd.read_csv(out_f, dtype=str)
+    assert out.iloc[0]['Timestamp'] == '00:00:00'
+    assert out.iloc[0]['Date'].startswith('2567')
+
+
 def test_auto_convert_csv_to_parquet_creates_file(tmp_path):
     df = pd.DataFrame({'a': [1], 'b': [2]})
     csv = tmp_path / 'sample.csv'

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -23,7 +23,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m1", 1224),
     ("src/data_loader.py", "load_raw_data_m15", 1234),
     ("src/data_loader.py", "write_test_file", 1240),
-    ("src/data_loader.py", "validate_csv_data", 1403),
+    ("src/data_loader.py", "validate_csv_data", 1454),
 
 
 


### PR DESCRIPTION
## Summary
- allow `auto_convert_gold_csv` to split `Timestamp` column when Date/Time columns are missing
- test timestamp-only conversion scenario
- update function registry expected line numbers

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684bdf591d9483258be87c07d1f80a5e