### PR TITLE
Fix Thai timestamp warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2164,3 +2164,8 @@ QA: pytest -q passed (219 tests)
   tests/test_data_cleaner.py::test_handle_missing_values_logging
 - QA: pytest -q passed (tests count TBD)
 
+### 2025-06-13
+- [Patch v6.9.13] Convert Thai timestamps to avoid warnings
+- New/Updated unit tests added for N/A
+- QA: pytest -q passed (1009 tests)
+

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1324,7 +1324,7 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
                     df["Date"].astype(str) + " " + df["Time"].astype(str), errors="coerce"
                 )
             elif "Timestamp" in df.columns:
-                dt = pd.to_datetime(df["Timestamp"].astype(str), errors="coerce")
+                dt = convert_thai_datetime(df["Timestamp"].astype(str), errors="coerce").dt.tz_localize(None)
             else:
                 print(f"ข้าม {f}: ไม่พบคอลัมน์ Date/Time")
                 continue


### PR DESCRIPTION
## Summary
- convert Thai timestamp strings using `convert_thai_datetime`
- document patch and test results in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be307ace48325b440945992b9d1b8