### PR TITLE
Add custom trade log file support

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -5,6 +5,7 @@ data:
   output_dir: "output_default"
   features_filename: "features_main.json"
   trade_log_pattern: "trade_log_*.csv*"
+  trade_log_file: "trade_log.csv"
   raw_m1_filename: "XAUUSD_M1.csv"
 cleaning:
   fill_method: "drop"

--- a/src/utils/pipeline_config.py
+++ b/src/utils/pipeline_config.py
@@ -16,6 +16,7 @@ class PipelineConfig:
     output_dir: str = 'output_default'
     features_filename: str = 'features_main.json'
     trade_log_pattern: str = 'trade_log_*.csv*'
+    trade_log_file: str | None = None
     raw_m1_filename: str = 'XAUUSD_M1.csv'
     cleaning_fill_method: str = 'drop'
 

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -19,13 +19,21 @@ def test_load_config_override(tmp_path):
 def test_load_config_data_section(tmp_path):
     conf_path = tmp_path / 'cfg.yaml'
     conf_path.write_text(
-        'data:\n  output_dir: odir\n  features_filename: f.json\n  trade_log_pattern: tl.csv\n  raw_m1_filename: raw.csv\n'
+        'data:\n  output_dir: odir\n  features_filename: f.json\n  trade_log_pattern: tl.csv\n  trade_log_file: real.csv\n  raw_m1_filename: raw.csv\n'
     )
     cfg = pipeline_config.load_config(str(conf_path))
     assert cfg.output_dir == 'odir'
     assert cfg.features_filename == 'f.json'
     assert cfg.trade_log_pattern == 'tl.csv'
     assert cfg.raw_m1_filename == 'raw.csv'
+    assert cfg.trade_log_file == 'real.csv'
+
+
+def test_load_config_trade_log_file(tmp_path):
+    conf_path = tmp_path / 'cfg.yaml'
+    conf_path.write_text('data:\n  trade_log_file: log.csv\n')
+    cfg = pipeline_config.load_config(str(conf_path))
+    assert cfg.trade_log_file == 'log.csv'
 
 
 def test_load_config_cleaning_section(tmp_path):


### PR DESCRIPTION
## Summary
- add `trade_log_file` option to pipeline configuration
- prefer explicit trade log file in `ProjectP`
- update YAML and tests for new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be690bfe883258c786b1b11daccb4