### PR TITLE
Implement strategy pattern with dependency injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2173,3 +2173,8 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for N/A
 - QA: pytest -q passed (1009 tests)
 
+### 2025-06-19
+- [Patch v6.9.15] Refactor strategy with Strategy Pattern
+- New/Updated unit tests added for tests/test_main_strategy_di.py
+- QA: pytest -q passed (1011 tests)
+

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -6,7 +6,12 @@ import pandas as pd
 import logging
 
 from src.config import DATA_FILE_PATH_M1, DATA_FILE_PATH_M15
-from src.strategy import run_backtest_simulation_v34
+from src.strategy import (
+    run_backtest_simulation_v34,
+    MainStrategy,
+    DefaultEntryStrategy,
+    DefaultExitStrategy,
+)
 from src.features import (
     engineer_m1_features,
     calculate_m15_trend_zone,
@@ -234,6 +239,9 @@ def run_full_backtest(config: dict):
     final_df.dropna(subset=["Trend_Zone"], inplace=True)
 
     logger.info(f"   (Success) รวมข้อมูลสำเร็จ, จำนวนแถวสุดท้าย: {len(final_df)}")
+
+    strategy_comp = MainStrategy(DefaultEntryStrategy(), DefaultExitStrategy())
+    _ = strategy_comp.get_signal(final_df)
 
     result = run_backtest_simulation_v34(
         final_df,

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -115,6 +115,75 @@ else:
     except Exception:
         nvml_handle = None
 
+# ---------------------------------------------------------------------------
+# Strategy Pattern Utilities
+# ---------------------------------------------------------------------------
+
+
+class EntryStrategy:
+    """Base class for entry signal generation."""
+
+    def check_entry(self, data):
+        raise NotImplementedError
+
+
+class ExitStrategy:
+    """Base class for exit signal generation."""
+
+    def check_exit(self, data):
+        raise NotImplementedError
+
+
+class RiskManagementStrategy:
+    """Base class for risk management adjustments."""
+
+    def manage_risk(self, signal, data):
+        return signal
+
+
+class TrendFilter:
+    """Base class for validating market trend."""
+
+    def is_valid(self, data) -> bool:
+        return True
+
+
+class DefaultEntryStrategy(EntryStrategy):
+    """Default entry handler using ``generate_open_signals``."""
+
+    def check_entry(self, data):
+        from strategy.entry_rules import generate_open_signals
+
+        signals = generate_open_signals(data)
+        return int(signals[-1]) if len(signals) else 0
+
+
+class DefaultExitStrategy(ExitStrategy):
+    """Default exit handler using ``generate_close_signals``."""
+
+    def check_exit(self, data):
+        from strategy.exit_rules import generate_close_signals
+
+        signals = generate_close_signals(data)
+        return int(signals[-1]) if len(signals) else 0
+
+
+class MainStrategy:
+    """Compose entry/exit/risk/trend components via dependency injection."""
+
+    def __init__(self, entry_handler, exit_handler, risk_manager=None, trend_filter=None):
+        self.entry_handler = entry_handler
+        self.exit_handler = exit_handler
+        self.risk_manager = risk_manager or RiskManagementStrategy()
+        self.trend_filter = trend_filter or TrendFilter()
+
+    def get_signal(self, data):
+        if not self.trend_filter.is_valid(data):
+            return 0
+        signal = self.entry_handler.check_entry(data)
+        return self.risk_manager.manage_risk(signal, data)
+
+
 # Ensure global configurations are accessible if run independently
 # Define defaults if globals are not found
 DEFAULT_META_CLASSIFIER_PATH = "meta_classifier.pkl"

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -45,13 +45,13 @@ FUNCTIONS_INFO = [
     ("src/main.py", "save_final_data", 2035),
     ("src/main.py", "run_auto_threshold_stage", 2041),
 
-    ("src/strategy.py", "run_backtest_simulation_v34", 1941),
-    ("src/strategy.py", "calculate_metrics", 3241),
-    ("src/strategy.py", "initialize_time_series_split", 4613),
-    ("src/strategy.py", "calculate_forced_entry_logic", 4616),
-    ("src/strategy.py", "apply_kill_switch", 4619),
-    ("src/strategy.py", "log_trade", 4622),
-    ("src/strategy.py", "aggregate_fold_results", 4625),
+    ("src/strategy.py", "run_backtest_simulation_v34", 2013),
+    ("src/strategy.py", "calculate_metrics", 3312),
+    ("src/strategy.py", "initialize_time_series_split", 4684),
+    ("src/strategy.py", "calculate_forced_entry_logic", 4687),
+    ("src/strategy.py", "apply_kill_switch", 4690),
+    ("src/strategy.py", "log_trade", 4693),
+    ("src/strategy.py", "aggregate_fold_results", 4696),
 
     ("ProjectP.py", "custom_helper_function", 104),
 ]

--- a/tests/test_main_strategy_di.py
+++ b/tests/test_main_strategy_di.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import sys
+sys.path.insert(0, '.')
+from src.strategy import (
+    MainStrategy,
+    EntryStrategy,
+    ExitStrategy,
+    RiskManagementStrategy,
+    TrendFilter,
+)
+
+class DummyEntry(EntryStrategy):
+    def __init__(self, result):
+        self.result = result
+    def check_entry(self, data):
+        return self.result
+
+class DummyExit(ExitStrategy):
+    def check_exit(self, data):
+        return 0
+
+class DummyRisk(RiskManagementStrategy):
+    def manage_risk(self, signal, data):
+        return signal * 2
+
+class DummyFilter(TrendFilter):
+    def __init__(self, valid):
+        self.valid = valid
+    def is_valid(self, data):
+        return self.valid
+
+def test_main_strategy_entry():
+    st = MainStrategy(DummyEntry(1), DummyExit(), DummyRisk(), DummyFilter(True))
+    assert st.get_signal(pd.DataFrame()) == 2
+
+def test_main_strategy_filter_blocks():
+    st = MainStrategy(DummyEntry(1), DummyExit(), DummyRisk(), DummyFilter(False))
+    assert st.get_signal(pd.DataFrame()) == 0


### PR DESCRIPTION
## Summary
- add Strategy Pattern utilities in `src/strategy.py`
- leverage new `MainStrategy` in `backtest_engine` as an example
- update function registry test offsets
- add unit tests for the new strategy DI logic
- record changes in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be728ee88832596e9d03c4e06deb7