### PR TITLE
Add constants for common column names

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,23 @@
+class ColumnName:
+    """Standard column names used throughout the project."""
+
+    OPEN = 'open'
+    HIGH = 'high'
+    LOW = 'low'
+    CLOSE = 'close'
+    VOLUME = 'volume'
+
+    OPEN_CAP = 'Open'
+    HIGH_CAP = 'High'
+    LOW_CAP = 'Low'
+    CLOSE_CAP = 'Close'
+    VOLUME_CAP = 'Volume'
+
+
+class Signal:
+    """Integer representations of trade signals."""
+
+    LONG = 1
+    SHORT = -1
+    NEUTRAL = 0
+

--- a/tests/test_entry_rules_module.py
+++ b/tests/test_entry_rules_module.py
@@ -1,9 +1,10 @@
 import pandas as pd
 from src import entry_rules, config
+from src.constants import ColumnName
 
 
 def test_dynamic_threshold_env(monkeypatch):
-    df = pd.DataFrame({'signal_score': [0.4, 0.7], 'close': [1, 1]})
+    df = pd.DataFrame({'signal_score': [0.4, 0.7], ColumnName.CLOSE: [1, 1]})
     monkeypatch.setenv('MIN_SIGNAL_SCORE_ENTRY', '0.5')
     signals = entry_rules.generate_open_signals(df)
     assert signals.tolist() == [0, 1]
@@ -11,7 +12,7 @@ def test_dynamic_threshold_env(monkeypatch):
 
 
 def test_ma_fallback(monkeypatch):
-    df = pd.DataFrame({'signal_score': [0, 0, 0, 0], 'close': [1, 2, 3, 4]})
+    df = pd.DataFrame({'signal_score': [0, 0, 0, 0], ColumnName.CLOSE: [1, 2, 3, 4]})
     monkeypatch.setenv('MIN_SIGNAL_SCORE_ENTRY', '5.0')
     monkeypatch.setattr(config, 'FAST_MA_PERIOD', 2)
     monkeypatch.setattr(config, 'SLOW_MA_PERIOD', 3)


### PR DESCRIPTION
## Summary
- centralize column names and signal values in `src/constants.py`
- refactor entry signal functions to use constants
- update entry rule tests to reference constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be9a1c4608325a0a4a18902d1a499