### PR TITLE
Optimize session tagging with vectorized helper

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility subpackage for shared helper functions."""
 
-from src.utils.sessions import get_session_tag
+from src.utils.sessions import get_session_tag, get_session_tags_vectorized
 from src.utils.trade_logger import (
     export_trade_log,
     aggregate_trade_logs,
@@ -31,6 +31,7 @@ from src.utils.leakage import hash_df, timestamp_split, assert_no_overlap
 
 __all__ = [
     "get_session_tag",
+    "get_session_tags_vectorized",
     "export_trade_log",
     "aggregate_trade_logs",
     "Order",


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `get_session_tags_vectorized` ใน `src/utils/sessions.py` เพื่อคำนวณ session แบบเวกเตอร์
- ปรับ `engineer_m1_features` และ `create_session_column` ให้ใช้ตัวช่วยใหม่
- เผยแพร่ฟังก์ชันผ่าน `src/utils/__init__.py`

## Testing
- `python3 run_tests.py --fast`

------
https://chatgpt.com/codex/tasks/task_e_684be73b56ac8325a39268c2fff0dcf2