### PR TITLE
[Patch v6.9.16] Load real trade log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# ### 2025-06-28
+- [Patch v6.9.16] Load real trade log and remove row limit instructions
+- New/Updated unit tests added for N/A
+- QA: pytest -q passed (tests count TBD)
+
 # ### 2025-06-27
 
 - [Patch v6.9.13] Log TA version from metadata

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -539,32 +539,35 @@ if __name__ == "__main__":
             )
     if not trade_log_file:
         if not log_files:
-            logger.warning(
-                "[Patch v6.4.6] No trade_log CSV found in %s; initializing empty trade log.",
-                output_dir,
-            )
-            # [Patch v6.7.2] Create a dummy trade log with placeholder rows (reduce to 9 rows)
-            trade_log_file = os.path.join(output_dir, "trade_log_dummy.csv")
-            dummy_cols = [
-                "entry_time",
-                "exit_time",
-                "entry_price",
-                "exit_price",
-                "side",
-                "profit",
-            ]
-            dummy_rows = [
-                {
-                    "entry_time": "",
-                    "exit_time": "",
-                    "entry_price": 0.0,
-                    "exit_price": 0.0,
-                    "side": "",
-                    "profit": 0.0,
-                }
-                for _ in range(9)
-            ]
-            pd.DataFrame(dummy_rows, columns=dummy_cols).to_csv(trade_log_file, index=False)
+            # [Patch v6.9.16] Prefer real trade_log.csv; fallback to dummy if missing
+            real_log = os.path.join(output_dir, "trade_log.csv")
+            if os.path.exists(real_log):
+                trade_log_file = real_log
+            else:
+                logger.warning(
+                    "trade_log.csv not found in %s; creating dummy log", output_dir
+                )
+                trade_log_file = os.path.join(output_dir, "trade_log_dummy.csv")
+                dummy_cols = [
+                    "entry_time",
+                    "exit_time",
+                    "entry_price",
+                    "exit_price",
+                    "side",
+                    "profit",
+                ]
+                dummy_rows = [
+                    {
+                        "entry_time": "",
+                        "exit_time": "",
+                        "entry_price": 0.0,
+                        "exit_price": 0.0,
+                        "side": "",
+                        "profit": 0.0,
+                    }
+                    for _ in range(9)
+                ]
+                pd.DataFrame(dummy_rows, columns=dummy_cols).to_csv(trade_log_file, index=False)
         else:
             log_files = sorted(log_files, key=lambda f: ("walkforward" not in f, f))
             trade_log_file = log_files[0]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ python main.py --mode all
 ใช้ `profile_backtest.py` เพื่อวัด bottleneck ของฟังก์ชันจำลองการเทรด
 ตัวอย่างการรัน:
 ```bash
-python profile_backtest.py XAUUSD_M1.csv --rows 10000 --limit 30 --output profile.txt --output-file backtest.prof
+python profile_backtest.py XAUUSD_M1.csv --limit 30 --output profile.txt --output-file backtest.prof
 ```
 คำสั่งด้านบนจะแสดง 30 ฟังก์ชันที่ใช้เวลามากที่สุดตามค่า `cumtime` จาก `cProfile` และบันทึกผลไว้ใน `profile.txt` รวมทั้งไฟล์ `backtest.prof` สำหรับเปิดใน SnakeViz.
 หากต้องการเก็บไฟล์ profiling แยกตามแต่ละรอบ ให้ระบุโฟลเดอร์ผ่าน `--output-profile-dir` ดังนี้:

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 ## การรัน Pipeline
 ใช้งานผ่านสคริปต์หลัก `ProjectP.py` หรือใช้ `profile_backtest.py` เพื่อประเมินประสิทธิภาพ ตัวอย่างเช่น
 ```bash
-python profile_backtest.py XAUUSD_M1.csv --rows 1000 --console_level WARNING
+python profile_backtest.py XAUUSD_M1.csv --console_level WARNING
 ```
 สำหรับการทดสอบรวดเร็ว สามารถระบุ `--debug` เพื่อลดจำนวนแถวที่โหลด
 ```bash


### PR DESCRIPTION
## Summary
- prefer real `trade_log.csv` instead of creating dummy file
- update profiling docs to remove `--rows` limitation
- refresh docs and changelog

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684befced1048325b38bbaf071ad9a39