### PR TITLE
Centralize config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # ### 2025-06-27
+- [Patch v6.9.16] Centralize config defaults in YAML
+- New/Updated unit tests added for N/A
+- QA: pytest -q passed (tests count TBD)
 
 - [Patch v6.9.13] Log TA version from metadata
 - New/Updated unit tests added for tests/test_ta_install.py

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,6 +1,10 @@
 cooldown_secs: 60
 kill_switch_pct: 0.2
 feature_format: parquet
+min_signal_score_entry: 0.3
+meta_filter_threshold: 0.5
+meta_filter_relaxed_threshold: 0.45
+meta_filter_relax_blocks: 5
 
 data:
   data_dir: 'data'

--- a/src/config.py
+++ b/src/config.py
@@ -137,13 +137,17 @@ from IPython import get_ipython
 import shutil
 import gzip
 import requests  # For Font Download
-from src.utils import get_env_float
+from src.utils import get_env_float, load_settings, log_settings
 
 import logging
 
 # [Patch] Ensure a module-level logger is always available for imports
 logger = logging.getLogger('NiceGold')
 logger.setLevel(logging.INFO)
+
+# Load runtime settings and log them
+SETTINGS = load_settings()
+log_settings(SETTINGS, logger)
 
 # -----------------------------------------------------------------------------
 # Fallback defaults for key constants used across the project.
@@ -806,8 +810,10 @@ OMS_MAX_DISTANCE_PIPS = 1000.0  # [Patch v5.5.8] Max allowed SL/TP distance
 
 # --- Entry/Exit Logic Parameters ---
 logging.debug("Setting Entry/Exit Logic Parameters...")
-# [Patch] Allow MIN_SIGNAL_SCORE_ENTRY override via environment
-MIN_SIGNAL_SCORE_ENTRY = get_env_float("MIN_SIGNAL_SCORE_ENTRY", 0.3)
+# [Patch v6.9.16] Load default from settings with env override
+MIN_SIGNAL_SCORE_ENTRY = get_env_float(
+    "MIN_SIGNAL_SCORE_ENTRY", SETTINGS.min_signal_score_entry
+)
 # [Patch v5.3.9] Adaptive threshold settings
 ADAPTIVE_SIGNAL_SCORE_WINDOW = 1000   # Bars used for quantile calculation
 ADAPTIVE_SIGNAL_SCORE_QUANTILE = 0.4  # [Patch v5.7.1] Lower quantile (40th)
@@ -901,10 +907,16 @@ logging.info(f"Re-Entry Enabled: {USE_REENTRY} (Cooldown: {REENTRY_COOLDOWN_BARS
 
 # --- Meta Filter Configuration ---
 logging.debug("Setting Meta Filter Configuration...")
-META_FILTER_THRESHOLD = get_env_float("META_FILTER_THRESHOLD", 0.5)
+META_FILTER_THRESHOLD = get_env_float(
+    "META_FILTER_THRESHOLD", SETTINGS.meta_filter_threshold
+)
 # ↓ ลดค่า Meta Filter เพื่อให้ผ่านโลจิก Meta-Model บ่อยขึ้น
-META_FILTER_RELAXED_THRESHOLD = get_env_float("META_FILTER_RELAXED_THRESHOLD", 0.45)
-META_FILTER_RELAX_BLOCKS = int(get_env_float("META_FILTER_RELAX_BLOCKS", 5))
+META_FILTER_RELAXED_THRESHOLD = get_env_float(
+    "META_FILTER_RELAXED_THRESHOLD", SETTINGS.meta_filter_relaxed_threshold
+)
+META_FILTER_RELAX_BLOCKS = int(
+    get_env_float("META_FILTER_RELAX_BLOCKS", SETTINGS.meta_filter_relax_blocks)
+)
 logging.info(
     f"Meta Filter Threshold: {META_FILTER_THRESHOLD} (Relaxed: {META_FILTER_RELAXED_THRESHOLD}, Blocks: {META_FILTER_RELAX_BLOCKS})"
 )

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -26,7 +26,7 @@ from src.utils.resource_plan import get_resource_plan, save_resource_plan
 from src.utils.hardware import estimate_resource_plan
 from src.utils.json_utils import load_json_with_comments
 from src.utils.module_utils import safe_reload
-from src.utils.settings import load_settings, Settings
+from src.utils.settings import load_settings, Settings, log_settings
 from src.utils.leakage import hash_df, timestamp_split, assert_no_overlap
 
 __all__ = [
@@ -57,5 +57,6 @@ __all__ = [
     "assert_no_overlap",
     "load_settings",
     "Settings",
+    "log_settings",
     "safe_reload",
 ]

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -13,6 +13,10 @@ class Settings:
     cooldown_secs: int = 60
     kill_switch_pct: float = 0.2
     feature_format: str = "parquet"
+    min_signal_score_entry: float = 0.3
+    meta_filter_threshold: float = 0.5
+    meta_filter_relaxed_threshold: float = 0.45
+    meta_filter_relax_blocks: int = 5
 
 
 def load_settings(path: str = DEFAULT_SETTINGS_FILE) -> Settings:
@@ -23,4 +27,12 @@ def load_settings(path: str = DEFAULT_SETTINGS_FILE) -> Settings:
         # [Patch v6.8.5] Merge YAML values with dataclass defaults
         return Settings(**{**Settings().__dict__, **data})
     return Settings()
+
+
+def log_settings(cfg: Settings, logger) -> None:
+    """Log all setting values via provided logger."""
+    from dataclasses import asdict
+
+    for key, value in asdict(cfg).items():
+        logger.info(f"[Settings] {key} = {value}")
 


### PR DESCRIPTION
## Summary
- expose more runtime settings in YAML
- log settings on module load
- export `log_settings` helper
- tests passing

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684bf16bd9c483258b1f066deedf8648