### PR TITLE
[Patch v6.8.7] Fix Thai Date Parsing & Feature Fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# ### 2025-07-03
+- [Patch v6.8.7] Fix Thai date parsing & feature fallback
+- New/Updated unit tests added for tests/test_safe_load_csv_limit.py
+- QA: pytest -q passed (tests count TBD)
+
 # ### 2025-07-02
 - [Patch v6.8.7] Normalize ปี พ.ศ. → ค.ศ. ก่อน parse
 - New/Updated unit tests added for tests/test_safe_load_csv_limit.py

--- a/ProjectP.py
+++ b/ProjectP.py
@@ -466,8 +466,12 @@ if __name__ == "__main__":
             logger.error("Cannot import feature builder: %s. Aborting.", ie)
             sys.exit(1)
         except Exception as ex:
-            logger.error("Failed to generate features_main.json: %s. Aborting.", ex)
-            sys.exit(1)
+            logger.warning(
+                "[Patch v6.8.7] Failed to generate features_main.json: %s. Continuing with minimal feature set",
+                ex,
+            )
+            features_main = []
+            save_features(features_main, features_path)
     else:
         logger.info(
             "Loaded existing features_main.json (%d bytes)",

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -387,7 +387,7 @@ def safe_load_csv_auto(file_path, row_limit=None, **kwargs):
     df.columns = [str(col).strip().lower() for col in df.columns]
 
     if 'timestamp' in df.columns:
-        df['timestamp'] = df['timestamp'].astype(str).apply(_normalize_thai_date)
+        df['timestamp'] = df['timestamp'].astype(str).apply(normalize_thai_date)
 
     # [Patch] รองรับคอลัมน์ชื่อ 'timestamp' แทน 'date/time'
     if 'date/time' not in df.columns:
@@ -1622,6 +1622,11 @@ def _normalize_thai_date(ts: str) -> str:
         return ts
 
 
+def normalize_thai_date(ts: str) -> str:
+    """Public wrapper for normalizing Thai Buddhist years."""
+    return _normalize_thai_date(ts)
+
+
 
 
 __all__ = [
@@ -1662,5 +1667,6 @@ __all__ = [
     "auto_convert_gold_csv",
     "auto_convert_csv_to_parquet",
     "load_project_csvs",
+    "normalize_thai_date",
 ]
 

--- a/tests/test_safe_load_csv_limit.py
+++ b/tests/test_safe_load_csv_limit.py
@@ -73,8 +73,8 @@ def test_safe_load_csv_auto_timestamp_column(tmp_path):
 
 
 def test_normalize_thai_date():
-    assert dl._normalize_thai_date('2567-01-01 00:00:00') == '2024-01-01 00:00:00'
-    assert dl._normalize_thai_date('2024-01-01 00:00:00') == '2024-01-01 00:00:00'
+    assert dl.normalize_thai_date('2567-01-01 00:00:00') == '2024-01-01 00:00:00'
+    assert dl.normalize_thai_date('2024-01-01 00:00:00') == '2024-01-01 00:00:00'
 
 
 def test_safe_load_csv_auto_timestamp_thai_year(tmp_path):


### PR DESCRIPTION
## Summary
- expose `normalize_thai_date` helper
- normalize `Timestamp` values in `safe_load_csv_auto`
- allow ProjectP to continue when feature catalog generation fails
- adjust tests for public helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cfb2c29148325ab3b40e24e5e8e66