### PR TITLE
แก้บัคปีพุทธศักราชใน prepare_datetime_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2221,3 +2221,8 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for tests/test_log_analysis.py::test_parse_gz_log
 - QA: pytest -q passed (567 tests)
 
+### 2025-07-02
+- [Patch v6.9.19] Fix Buddhist year conversion in prepare_datetime_index
+- New/Updated unit tests added for tests/test_loader_main_functions.py::test_prepare_datetime_index_buddhist_year
+- QA: pytest -q passed (1010 tests)
+

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1225,7 +1225,8 @@ def prepare_datetime_index(df):
     if 'Timestamp' not in df.columns and 'Date' in df.columns:
         df = df.rename(columns={'Date': 'Timestamp'})
     if 'Timestamp' in df.columns:
-        df.index = pd.to_datetime(df['Timestamp'], errors='coerce')
+        ts = df['Timestamp'].astype(str).apply(normalize_thai_date)
+        df.index = pd.to_datetime(ts, errors='coerce')
     return df
 
 
@@ -1608,6 +1609,11 @@ def _normalize_thai_date(ts: str) -> str:
         return ts
     except Exception:
         return ts
+
+
+def normalize_thai_date(ts: str) -> str:
+    """Public wrapper for :func:`_normalize_thai_date`."""
+    return _normalize_thai_date(ts)
 
 
 

--- a/tests/test_loader_main_functions.py
+++ b/tests/test_loader_main_functions.py
@@ -61,6 +61,12 @@ def test_prepare_datetime_index_sets_index():
     assert isinstance(res.index, pd.DatetimeIndex)
 
 
+def test_prepare_datetime_index_buddhist_year():
+    df = pd.DataFrame({'Timestamp': ['2563-06-12 03:00:00']})
+    res = dl.prepare_datetime_index(df.copy())
+    assert res.index[0] == pd.Timestamp('2020-06-12 03:00:00')
+
+
 def test_drop_nan_rows_drops_na():
     df = pd.DataFrame({'A': [1, np.nan]})
     res = main.drop_nan_rows(df)


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `normalize_thai_date` และเรียกใช้ใน `prepare_datetime_index`
- ปรับ `prepare_datetime_index` ให้แปลงปี พ.ศ. ก่อนตั้ง `DatetimeIndex`
- เพิ่มกรณีทดสอบรองรับปี พ.ศ.
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d01db92a083258034a74ec72b3c22