### PR TITLE
Improve ProjectP full pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2241,3 +2241,7 @@ QA: pytest -q passed (219 tests)
 - New/Updated unit tests added for tests/test_main_cli_extended.py::test_main_debug_sets_sample_size
 - QA: pytest -q passed (1011 tests)
 
+### 2025-07-06
+- [Patch v6.9.23] Enterprise run_full_pipeline logging and verification
+- New/Updated unit tests added for tests/test_projectp_execute_step.py
+- QA: pytest -q passed (partial)

--- a/tests/test_projectp_cli.py
+++ b/tests/test_projectp_cli.py
@@ -88,8 +88,9 @@ def test_run_full_pipeline_sequence(monkeypatch):
     )
     monkeypatch.setattr(proj, 'run_backtest', lambda: calls.append('back'))
     monkeypatch.setattr(proj, 'run_report', lambda: calls.append('rep'))
+    monkeypatch.setattr(proj, 'ensure_output_files', lambda files: calls.append('ensure'))
     proj.run_full_pipeline()
-    assert calls == ['pre', 'sweep', 'th', 'back', 'rep']
+    assert calls == ['pre', 'sweep', 'th', 'back', 'rep', 'ensure']
 
 
 def test_run_mode_wfv(monkeypatch):

--- a/tests/test_projectp_execute_step.py
+++ b/tests/test_projectp_execute_step.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import logging
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+import ProjectP as proj
+
+
+def test_execute_step_logs_and_returns(caplog):
+    called = {}
+
+    def dummy():
+        called['ok'] = True
+        return 123
+
+    with caplog.at_level(logging.INFO, logger=proj.logger.name):
+        result = proj._execute_step('dummy', dummy)
+
+    assert result == 123
+    assert called.get('ok') is True
+    assert any('completed in' in rec.message and 'dummy' in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `_execute_step` helper for timing and logging
- log each stage inside `run_full_pipeline`
- verify results via `ensure_output_files`
- test the new helper and updated sequence logic

## Testing
- `pytest tests/test_projectp_execute_step.py tests/test_projectp_cli.py::test_run_full_pipeline_sequence -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7c35d0148325a19098f2ed45a68b