### PR TITLE
Add live trading loop flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2263,3 +2263,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.9.26] Rename Timestamp column to Date in CSVs
 
 - QA: pytest -q passed (tests count TBD)
+### 2025-07-10
+- [Patch v6.9.27] Add --live-loop option for live trading loop
+- New/Updated unit tests added for tests/test_main_cli_extended.py::test_parse_args_live_loop_default and test_main_live_loop_called
+- QA: pytest -q failed (10 tests failed)
+

--- a/main.py
+++ b/main.py
@@ -96,6 +96,12 @@ def parse_args(args=None) -> argparse.Namespace:
         default="backtest_profile.prof",
         help="Profiling output file",
     )
+    parser.add_argument(
+        "--live-loop",
+        type=int,
+        default=0,
+        help="Run live trading loop after pipeline (number of iterations)",
+    )
     return parser.parse_args(args)
 
 
@@ -312,6 +318,10 @@ def main(args=None) -> int:
             run_report(config)
         else:
             run_all(config)
+
+        if parsed.live_loop > 0:
+            import src.main as src_main
+            src_main.run_live_trading_loop(parsed.live_loop)
     except PipelineError as exc:
         logger.error("Pipeline error: %s", exc, exc_info=True)
         return 1

--- a/tests/test_main_cli_extended.py
+++ b/tests/test_main_cli_extended.py
@@ -50,6 +50,11 @@ def test_parse_args_debug_rows():
     assert args.rows == 123
 
 
+def test_parse_args_live_loop_default():
+    args = pipeline.parse_args([])
+    assert args.live_loop == 0
+
+
 def test_run_preprocess_success():
     called = []
     def fake_run(cmd, check):
@@ -191,3 +196,16 @@ def test_main_rows_override(monkeypatch):
     pipeline.main(['--rows', '123'])
     assert src_main.sample_size == 123
     assert strategy.sample_size == 123
+
+
+def test_main_live_loop_called(monkeypatch):
+    called = {}
+    monkeypatch.setattr(pipeline, 'run_backtest', lambda c: None)
+    monkeypatch.setattr(pipeline, 'run_all', lambda c: None)
+    monkeypatch.setattr(pipeline, 'setup_logging', lambda level: None)
+    monkeypatch.setattr(pipeline, 'load_config', lambda p: PipelineConfig())
+    monkeypatch.setattr(pipeline, 'has_gpu', lambda: False)
+    import src.main as src_main
+    monkeypatch.setattr(src_main, 'run_live_trading_loop', lambda n: called.setdefault('loop', n))
+    pipeline.main(['--mode', 'backtest', '--live-loop', '3'])
+    assert called.get('loop') == 3


### PR DESCRIPTION
## Summary
- add `--live-loop` option for running a live trading loop after pipeline completion
- invoke live trading loop when the flag is set
- test CLI parsing and live loop invocation
- document patch

## Testing
- `pytest -q` *(fails: DataValidationError and other 9 failures)*

------
https://chatgpt.com/codex/tasks/task_e_684d96609c008325aedbe322969e159f