### PR TITLE
Fix auto_convert gold csv timestamp handling

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1372,7 +1372,14 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
         out_f = os.path.join(target_dir, base_out)
         try:
             df = pd.read_csv(f)
-            df.columns = [c.capitalize() for c in df.columns]
+            df.columns = [c.strip() for c in df.columns]
+
+            # [Patch] รองรับคอลัมน์ชื่ออื่น ๆ เช่น "DateTime" หรือ "Datetime"
+            alt_time_cols = ["DateTime", "Datetime", "datetime", "date/time"]
+            for alt in alt_time_cols:
+                if alt in df.columns and "Timestamp" not in df.columns:
+                    df.rename(columns={alt: "Timestamp"}, inplace=True)
+                    break
 
             if "Date" in df.columns and "Time" in df.columns:
                 ts = df["Date"].astype(str) + " " + df["Time"].astype(str)

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -24,7 +24,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m15", 1287),
     ("src/data_loader.py", "write_test_file", 1293),
 
-    ("src/data_loader.py", "validate_csv_data", 1512),
+    ("src/data_loader.py", "validate_csv_data", 1523),
 
 
 


### PR DESCRIPTION
## Summary
- handle datetime column variants like `DateTime` in `auto_convert_gold_csv`
- update line references in test_function_registry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db405d4588325bfe063049ddac95e