### PR TITLE
Fix AutoConvert datetime detection

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1372,8 +1372,10 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
         out_f = os.path.join(target_dir, base_out)
         try:
             df = pd.read_csv(f)
+            df.columns = [c.strip() for c in df.columns]
             df.columns = [c.capitalize() for c in df.columns]
 
+            # [Patch v6.9.33] Handle alternative datetime column names
             if "Date" in df.columns and "Time" in df.columns:
                 ts = df["Date"].astype(str) + " " + df["Time"].astype(str)
                 converted = ts.apply(_extract_thai_date_time)
@@ -1384,8 +1386,16 @@ def auto_convert_gold_csv(data_dir="data", output_path=None):
                 df["Date"] = [c[0] for c in converted]
                 df["Timestamp"] = [c[1] for c in converted]
             else:
-                print(f"ข้าม {f}: ไม่พบคอลัมน์ Date/Time")
-                continue
+                for alt in ["Datetime", "Date/time", "DateTime", "datetime"]:
+                    if alt in df.columns:
+                        df.rename(columns={alt: "Timestamp"}, inplace=True)
+                        converted = df["Timestamp"].apply(_extract_thai_date_time)
+                        df["Date"] = [c[0] for c in converted]
+                        df["Timestamp"] = [c[1] for c in converted]
+                        break
+                else:
+                    print(f"ข้าม {f}: ไม่พบคอลัมน์ Date/Time")
+                    continue
 
             for col in ["Open", "High", "Low", "Close"]:
                 if col not in df.columns and col.lower() in df.columns:

--- a/tests/test_auto_convert_csv.py
+++ b/tests/test_auto_convert_csv.py
@@ -96,6 +96,24 @@ def test_auto_convert_gold_csv_timestamp_only(tmp_path):
     assert out.iloc[0]['Date'].startswith('2567')
 
 
+def test_auto_convert_gold_csv_datetime_alias(tmp_path):
+    df = pd.DataFrame({
+        'DateTime': ['2024-01-01 00:00:00'],
+        'Open': [1.0],
+        'High': [1.1],
+        'Low': [0.9],
+        'Close': [1.0],
+    })
+    csv = tmp_path / 'XAUUSD_M1.csv'
+    df.to_csv(csv, index=False)
+    out_f = tmp_path / 'XAUUSD_M1_thai.csv'
+    auto_convert_gold_csv(str(tmp_path), output_path=str(out_f))
+    assert out_f.exists()
+    out = pd.read_csv(out_f, dtype=str)
+    assert out.iloc[0]['Timestamp'] == '00:00:00'
+    assert out.iloc[0]['Date'].startswith('2567')
+
+
 def test_auto_convert_csv_to_parquet_creates_file(tmp_path):
     df = pd.DataFrame({'a': [1], 'b': [2]})
     csv = tmp_path / 'sample.csv'

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -24,7 +24,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m15", 1287),
     ("src/data_loader.py", "write_test_file", 1293),
 
-    ("src/data_loader.py", "validate_csv_data", 1512),
+    ("src/data_loader.py", "validate_csv_data", 1526),
 
 
 


### PR DESCRIPTION
## Summary
- improve auto_convert_gold_csv to detect more datetime column names
- strip whitespace from column headers
- test datetime alias handling
- update function registry test line numbers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db97b9ce883259be55c45c4bcfdee