### PR TITLE
[Patch v6.9.33] ปรับปรุง auto_convert_gold_csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# ### 2025-07-05
+- [Patch v6.9.33] ปรับปรุงตัวแปลงวันที่ใน auto_convert_gold_csv
+- New/Updated unit tests added for tests/test_auto_convert_csv.py
+- QA: pytest -q passed (435 tests)
+
 # ### 2025-07-04
 - [Patch v6.9.32] Fix ProjectP preprocess mode dispatch
 - New/Updated unit tests added for N/A

--- a/tests/test_auto_convert_csv.py
+++ b/tests/test_auto_convert_csv.py
@@ -96,6 +96,24 @@ def test_auto_convert_gold_csv_timestamp_only(tmp_path):
     assert out.iloc[0]['Date'].startswith('2567')
 
 
+def test_auto_convert_gold_csv_datetime_alias(tmp_path):
+    df = pd.DataFrame({
+        'DateTime': ['2024-01-01 00:00:00'],
+        'Open': [1.0],
+        'High': [1.1],
+        'Low': [0.9],
+        'Close': [1.0],
+    })
+    csv = tmp_path / 'XAUUSD_M1.csv'
+    df.to_csv(csv, index=False)
+    out_f = tmp_path / 'XAUUSD_M1_thai.csv'
+    auto_convert_gold_csv(str(tmp_path), output_path=str(out_f))
+    assert out_f.exists()
+    out = pd.read_csv(out_f, dtype=str)
+    assert out.iloc[0]['Timestamp'] == '00:00:00'
+    assert out.iloc[0]['Date'].startswith('2567')
+
+
 def test_auto_convert_csv_to_parquet_creates_file(tmp_path):
     df = pd.DataFrame({'a': [1], 'b': [2]})
     csv = tmp_path / 'sample.csv'

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -24,7 +24,7 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "load_raw_data_m15", 1287),
     ("src/data_loader.py", "write_test_file", 1293),
 
-    ("src/data_loader.py", "validate_csv_data", 1523),
+    ("src/data_loader.py", "validate_csv_data", 1526),
 
 
 


### PR DESCRIPTION
## Summary
- ปรับปรุงให้ `auto_convert_gold_csv` รองรับคอลัมน์ชื่อ DateTime/Datetime/Date/time
- ตัดช่องว่างและแปลงชื่อคอลัมน์เป็นตัวพิมพ์ใหญ่ต้นคำ
- เพิ่ม unit test ตรวจสอบการอ่านคอลัมน์ DateTime
- ปรับเลขบรรทัดใน test_function_registry
- อัปเดต CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbc89a6a083258c1164293d0c231a