### PR TITLE
Add drive path detection in config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -532,8 +532,12 @@ def is_colab():
 
 FILE_BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 FILE_BASE_OVERRIDE = os.getenv("FILE_BASE_OVERRIDE")
+DRIVE_BASE_PATH = "/content/drive/MyDrive/Phiradon168"
 if FILE_BASE_OVERRIDE and os.path.isdir(FILE_BASE_OVERRIDE):
     FILE_BASE = FILE_BASE_OVERRIDE
+elif os.path.isdir(DRIVE_BASE_PATH):
+    # [Patch] ใช้โฟลเดอร์ Google Drive หากมีให้บริการแม้ไม่อยู่ใน Colab
+    FILE_BASE = DRIVE_BASE_PATH
 elif is_colab():
     from google.colab import drive
     logging.info("(Info) รันบน Google Colab – กำลัง mount Google Drive...")

--- a/tests/test_config_extended.py
+++ b/tests/test_config_extended.py
@@ -85,3 +85,19 @@ def test_file_base_mount_failure_fallback(monkeypatch, tmp_path):
     config = _import_config(monkeypatch)
     expected = os.path.abspath(os.path.join(os.path.dirname(config.__file__), '..'))
     assert config.FILE_BASE == expected
+
+
+def test_file_base_detect_drive(monkeypatch):
+    """FILE_BASE should point to Google Drive path when available."""
+    monkeypatch.delenv('FILE_BASE_OVERRIDE', raising=False)
+    monkeypatch.delenv('COLAB_RELEASE_TAG', raising=False)
+    monkeypatch.delenv('COLAB_GPU', raising=False)
+    # Patch os.path.isdir to simulate Drive folder present
+    original_isdir = os.path.isdir
+    def fake_isdir(path):
+        if path == '/content/drive/MyDrive/Phiradon168':
+            return True
+        return original_isdir(path)
+    monkeypatch.setattr(os.path, 'isdir', fake_isdir)
+    config = _import_config(monkeypatch)
+    assert config.FILE_BASE == '/content/drive/MyDrive/Phiradon168'

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -7,8 +7,8 @@ FUNCTIONS_INFO = [
     ("src/config.py", "log_library_version", 222),
     ("src/config.py", "_ensure_ta_installed", 267),
     ("src/config.py", "is_colab", 506),
-    ("src/config.py", "print_gpu_utilization", 607),
-    ("src/config.py", "show_system_status", 659),
+    ("src/config.py", "print_gpu_utilization", 616),
+    ("src/config.py", "show_system_status", 668),
 
 
 


### PR DESCRIPTION
## Summary
- support running outside Colab by detecting `/content/drive/MyDrive/Phiradon168`
- test detection logic in `test_config_extended`
- update `test_function_registry` line numbers

## Testing
- `pytest tests/test_config_extended.py::test_file_base_detect_drive -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dccece3ec83258d02de1ebdbe2c03