### PR TITLE
Fix CSV loading with Time column

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -424,6 +424,9 @@ def safe_load_csv_auto(file_path, row_limit=None, **kwargs):
     elif 'timestamp' in df.columns:
         logger.info("ตรวจพบ คอลัมน์ 'timestamp', กำลังแปลงข้อมูล...")
         datetime_col = 'timestamp'
+    elif 'time' in df.columns and datetime_col is None:
+        logger.info("ตรวจพบ คอลัมน์ 'time', กำลังแปลงข้อมูล...")
+        datetime_col = 'time'
 
     if datetime_col:
         with warnings.catch_warnings():

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -22,9 +22,9 @@ FUNCTIONS_INFO = [
     ("src/data_loader.py", "prepare_datetime_index", 1220),
     ("src/data_loader.py", "load_raw_data_m1", 1277),
     ("src/data_loader.py", "load_raw_data_m15", 1287),
-    ("src/data_loader.py", "write_test_file", 1293),
+    ("src/data_loader.py", "write_test_file", 1299),
 
-    ("src/data_loader.py", "validate_csv_data", 1531),
+    ("src/data_loader.py", "validate_csv_data", 1538),
 
 
 

--- a/tests/test_safe_load_csv_limit.py
+++ b/tests/test_safe_load_csv_limit.py
@@ -72,6 +72,21 @@ def test_safe_load_csv_auto_timestamp_column(tmp_path):
     assert isinstance(result.index, pd.DatetimeIndex)
 
 
+def test_safe_load_csv_auto_time_column(tmp_path):
+    df = pd.DataFrame({
+        'Time': ['2024-01-01 00:00:00'],
+        'Open': [1],
+        'High': [1],
+        'Low': [1],
+        'Close': [1],
+    })
+    p = tmp_path / 'time.csv'
+    df.to_csv(p, index=False)
+    result = dl.safe_load_csv_auto(str(p))
+    assert isinstance(result.index, pd.DatetimeIndex)
+    assert result.index[0] == pd.Timestamp('2024-01-01 00:00:00')
+
+
 def test_normalize_thai_date():
     assert dl.normalize_thai_date('2567-01-01 00:00:00') == '2024-01-01 00:00:00'
     assert dl.normalize_thai_date('2024-01-01 00:00:00') == '2024-01-01 00:00:00'


### PR DESCRIPTION
## Summary
- support `Time` column in `safe_load_csv_auto`
- test that `Time` column is handled
- update expected line numbers in test suite

## Testing
- `python run_tests.py --fast`

------
https://chatgpt.com/codex/tasks/task_e_684ddb36c1bc83258b8063bdd5547c17