### PR TITLE
[Patch v6.9.36] Refactor OMS helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2338,3 +2338,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.9.35] Split features into package modules
 - New/Updated unit tests added for N/A
 - QA: pytest -q failed
+
+### 2025-07-19
+- [Patch v6.9.36] Move OMS helpers to order_management module
+- New/Updated unit tests added for N/A
+- QA: pytest -q failed (environment limits)

--- a/strategy/order_management.py
+++ b/strategy/order_management.py
@@ -7,6 +7,8 @@ from enum import Enum
 from threading import Lock
 from typing import Dict
 import logging
+import math
+import pandas as pd
 
 from src.utils import load_settings, Settings
 
@@ -99,3 +101,80 @@ def create_order(side: str, price: float, sl: float, tp: float) -> Dict:
     }
 
 __all__.append("create_order")
+
+
+def adjust_sl_tp_oms(
+    entry_price: float,
+    sl_price: float,
+    tp_price: float,
+    atr: float,
+    side: str,
+    margin_pips: float,
+    max_pips: float,
+) -> tuple[float, float]:
+    """Validate SL/TP distance and auto-adjust if outside allowed range."""
+    if any(pd.isna(v) for v in [entry_price, sl_price, tp_price, atr]):
+        return sl_price, tp_price
+
+    sl_dist = abs(entry_price - sl_price) * 10.0
+    tp_dist = abs(tp_price - entry_price) * 10.0
+
+    if sl_dist < margin_pips:
+        adj = atr if pd.notna(atr) and atr > 1e-9 else margin_pips / 10.0
+        sl_price = entry_price - adj if side == "BUY" else entry_price + adj
+        logging.info("[OMS_Guardian] Adjust SL to margin level: %.5f", sl_price)
+
+    if sl_dist > max_pips:
+        sl_price = entry_price - atr if side == "BUY" else entry_price + atr
+        logging.info(
+            "[OMS_Guardian] SL distance too wide. Adjusted to %.5f", sl_price
+        )
+
+    if tp_dist > max_pips:
+        tp_price = entry_price + atr if side == "BUY" else entry_price - atr
+        logging.info(
+            "[OMS_Guardian] TP distance too wide. Adjusted to %.5f", tp_price
+        )
+
+    return sl_price, tp_price
+
+
+def update_breakeven_half_tp(
+    order: Dict,
+    current_high: float,
+    current_low: float,
+    now: pd.Timestamp,
+    entry_buffer: float = 0.0001,
+) -> tuple[Dict, bool]:
+    """Move SL to breakeven when price moves halfway to TP1."""
+    if order.get("be_triggered", False):
+        return order, False
+
+    side = order.get("side")
+    entry = pd.to_numeric(order.get("entry_price"), errors="coerce")
+    tp1 = pd.to_numeric(order.get("tp1_price"), errors="coerce")
+    sl = pd.to_numeric(order.get("sl_price"), errors="coerce")
+
+    if any(pd.isna(v) for v in [side, entry, tp1, sl]):
+        return order, False
+
+    trigger = entry + 0.5 * (tp1 - entry) if side == "BUY" else entry - 0.5 * (
+        entry - tp1
+    )
+    hit = (side == "BUY" and current_high >= trigger) or (
+        side == "SELL" and current_low <= trigger
+    )
+
+    if hit:
+        new_sl = entry + entry_buffer if side == "BUY" else entry - entry_buffer
+        if not math.isclose(new_sl, sl, rel_tol=1e-9, abs_tol=1e-9):
+            order["sl_price"] = new_sl
+            order["be_triggered"] = True
+            order["be_triggered_time"] = now
+            logging.info("Move to Breakeven at price %.5f", new_sl)
+            return order, True
+
+    return order, False
+
+
+__all__ += ["adjust_sl_tp_oms", "update_breakeven_half_tp"]


### PR DESCRIPTION
## Summary
- move `adjust_sl_tp_oms` and `update_breakeven_half_tp` to `strategy/order_management`
- delegate wrappers in `src/strategy.py`
- document change in CHANGELOG

## Testing
- `python3 run_tests.py --fast` *(fails: FileNotFoundError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_684e3d893cb88325a166576c026954f2