### PR TITLE
Implement improved CSV validation and loading

### DIFF
--- a/tests/test_safe_load_csv.py
+++ b/tests/test_safe_load_csv.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import src.data_loader as dl
+
+
+def test_safe_load_csv_basic(tmp_path):
+    df = pd.DataFrame({
+        'Date': ['25670101', '25670101'],
+        'Timestamp': ['00:00:00', '00:00:00'],
+        'Open': [1, 1],
+        'High': [2, 2],
+        'Low': [0.5, 0.5],
+        'Close': [1.5, 1.5],
+        'Volume': [10, 10],
+    })
+    csv = tmp_path / 'in.csv'
+    df.to_csv(csv, index=False)
+    result = dl.safe_load_csv(str(csv))
+    assert len(result) == 1
+    assert isinstance(result.index, pd.DatetimeIndex)
+    assert result['Volume'].dtype == 'int64'

--- a/tests/test_thai_utils.py
+++ b/tests/test_thai_utils.py
@@ -34,6 +34,30 @@ def test_validate_csv_data_empty():
         validate_csv_data(pd.DataFrame(), ['A'])
 
 
+def test_validate_csv_data_type_fail():
+    df = pd.DataFrame({'Open': ['x'], 'High': [1], 'Low': [0], 'Close': [1], 'Volume': [1]})
+    with pytest.raises(TypeError):
+        validate_csv_data(df, ['Open', 'High', 'Low', 'Close', 'Volume'])
+
+
+def test_validate_csv_data_integrity_fail():
+    df = pd.DataFrame({'Open': [1], 'High': [0], 'Low': [1], 'Close': [1], 'Volume': [1]})
+    with pytest.raises(ValueError):
+        validate_csv_data(df, ['Open', 'High', 'Low', 'Close', 'Volume'])
+
+
+def test_validate_csv_data_negative_volume():
+    df = pd.DataFrame({'Open': [1], 'High': [1], 'Low': [0], 'Close': [1], 'Volume': [-1]})
+    with pytest.raises(ValueError):
+        validate_csv_data(df, ['Open', 'High', 'Low', 'Close', 'Volume'])
+
+
+def test_validate_csv_data_missing_value():
+    df = pd.DataFrame({'Open': [1], 'High': [1], 'Low': [0], 'Close': [None], 'Volume': [1]})
+    with pytest.raises(ValueError):
+        validate_csv_data(df, ['Open', 'High', 'Low', 'Close', 'Volume'])
+
+
 def test_estimate_resource_plan_defaults(monkeypatch):
     monkeypatch.delitem(sys.modules, 'psutil', raising=False)
     plan = estimate_resource_plan()


### PR DESCRIPTION
## Summary
- add schema and safe CSV loader
- extend `validate_csv_data` checks
- unit tests for new validation cases and loader

## Testing
- `pytest -q` *(fails: 26 failed, 327 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684e4a3429488325a40e857290995f87