### PR TITLE
[Patch v6.9.42] Fix preprocess recursion

### DIFF
--- a/ProjectP.py
+++ b/ProjectP.py
@@ -169,7 +169,12 @@ def parse_args(args=None):  # backward compatibility
 
 def run_preprocess():
     """รันขั้นตอนเตรียมข้อมูลและฝึกโมเดล."""
-    pipeline_run_preprocess(pipeline_config)
+    # [Patch v6.9.42] Set flag to avoid recursive subprocess calls
+    os.environ["FROM_PROJECTP"] = "1"
+    try:
+        pipeline_run_preprocess(pipeline_config)
+    finally:
+        os.environ.pop("FROM_PROJECTP", None)
 
 
 def _run_script(relative_path: str) -> None:

--- a/main.py
+++ b/main.py
@@ -156,7 +156,9 @@ def run_preprocess(config: PipelineConfig, runner=subprocess.run) -> None:
             ],
             check=True,
         )
-        runner([os.environ.get("PYTHON", "python"), "ProjectP.py"], check=True)
+        # [Patch v6.9.42] Prevent infinite recursion when ProjectP calls pipeline
+        if not os.getenv("FROM_PROJECTP"):
+            runner([os.environ.get("PYTHON", "python"), "ProjectP.py"], check=True)
     except subprocess.CalledProcessError as exc:
         logger.error("Preprocess failed", exc_info=True)
         raise PipelineError("preprocess stage failed") from exc

--- a/src/utils/data_utils.py
+++ b/src/utils/data_utils.py
@@ -62,7 +62,12 @@ def safe_read_csv(path: str) -> pd.DataFrame:
     try:
         from src.data_cleaner import read_csv_auto, convert_buddhist_year
 
-        df = read_csv_auto(path)
+        if str(path).endswith(".gz") or str(path).endswith(".zip"):
+            # [Patch v6.9.42] Support gzip/zip via pandas compression inference
+            df = pd.read_csv(path, compression="infer")
+        else:
+            df = read_csv_auto(path)
+
         if {"Date", "Timestamp"}.issubset(df.columns):
             df = convert_buddhist_year(df)
         return df


### PR DESCRIPTION
## Summary
- stop infinite subprocess loop by marking calls from ProjectP
- skip ProjectP subprocess when flag present in `main.run_preprocess`
- allow `safe_read_csv` to handle gzip/zip files

## Testing
- `python run_tests.py --fast`

------
https://chatgpt.com/codex/tasks/task_e_684e7f9fc27c8325aefe1dec48cf479c