### PR TITLE
Fix config to specify parquet_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New/Updated unit tests added for tests/test_auto_train_meta_classifiers.py
 - QA: pytest -q passed (354 tests)
 
+### 2025-07-24
+- [Patch v6.9.43] Add parquet_dir to pipeline config
+- New/Updated unit tests added for tests/test_pipeline_config.py::test_load_config_parquet_dir
+- QA: pytest -q passed (438 tests)
+
 
 ### 2025-07-22
 - [Patch v6.9.41] Fix environment overrides and auto-train helper

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -7,5 +7,6 @@ data:
   trade_log_pattern: "trade_log_*.csv*"
   trade_log_file: "trade_log.csv"
   raw_m1_filename: "XAUUSD_M1.csv"
+  parquet_dir: "data/parquet_cache"
 cleaning:
   fill_method: "drop"

--- a/src/utils/pipeline_config.py
+++ b/src/utils/pipeline_config.py
@@ -19,6 +19,7 @@ class PipelineConfig:
     trade_log_file: str | None = None
     raw_m1_filename: str = 'XAUUSD_M1.csv'
     cleaning_fill_method: str = 'drop'
+    parquet_dir: str | None = None
 
 
 def load_config(path: str = DEFAULT_CONFIG_FILE) -> 'PipelineConfig':

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -41,3 +41,10 @@ def test_load_config_cleaning_section(tmp_path):
     conf_path.write_text('cleaning:\n  fill_method: mean\n')
     cfg = pipeline_config.load_config(str(conf_path))
     assert cfg.cleaning_fill_method == 'mean'
+
+
+def test_load_config_parquet_dir(tmp_path):
+    conf_path = tmp_path / 'cfg.yaml'
+    conf_path.write_text('data:\n  parquet_dir: cache\n')
+    cfg = pipeline_config.load_config(str(conf_path))
+    assert cfg.parquet_dir == 'cache'


### PR DESCRIPTION
## Summary
- add `parquet_dir` to `PipelineConfig`
- default `parquet_dir` in `config/pipeline.yaml`
- test new config field
- log changelog entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8a066d4c832587b2f6e7586e9218