### PR TITLE
Improve time column detection in auto_convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2422,3 +2422,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.9.44] Update ProjectP CLI to new mode-based syntax
 - New/Updated unit tests added for N/A
 - QA: pytest -q passed (existing tests)
+
+### 2025-07-26
+- [Patch v6.9.45] Improve time column detection for auto_convert_gold_csv
+- New/Updated unit tests added for tests/test_auto_convert_csv.py
+- QA: pytest -q passed

--- a/tests/test_auto_convert_csv.py
+++ b/tests/test_auto_convert_csv.py
@@ -126,6 +126,24 @@ def test_auto_convert_gold_csv_bom_header(tmp_path):
     assert out.iloc[0]['Timestamp'] == '00:00:00'
 
 
+def test_auto_convert_gold_csv_parentheses_time(tmp_path):
+    df = pd.DataFrame({
+        'Date/Time (UTC)': ['2024-01-01 00:00:00'],
+        'Open': [1.0],
+        'High': [1.1],
+        'Low': [0.9],
+        'Close': [1.0],
+    })
+    csv = tmp_path / 'XAUUSD_M1.csv'
+    df.to_csv(csv, index=False)
+    out_f = tmp_path / 'XAUUSD_M1_thai.csv'
+    auto_convert_gold_csv(str(tmp_path), output_path=str(out_f))
+    assert out_f.exists()
+    out = pd.read_csv(out_f, dtype=str)
+    assert out.iloc[0]['Timestamp'] == '00:00:00'
+    assert out.iloc[0]['Date'].startswith('2567')
+
+
 def test_auto_convert_csv_to_parquet_creates_file(tmp_path):
     df = pd.DataFrame({'a': [1], 'b': [2]})
     csv = tmp_path / 'sample.csv'


### PR DESCRIPTION
## Summary
- handle weird timestamp column names by cleaning extra symbols
- extend detection list in `auto_convert_gold_csv`
- add unit test for columns like `Date/Time (UTC)`
- document patch in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea7a5bce88325941e3993cbfd5fe1