### PR TITLE
Add env override for adaptive quantile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2442,3 +2442,8 @@ QA: pytest -q passed (219 tests)
 - [Patch v6.9.45] Improve time column detection for auto_convert_gold_csv
 - New/Updated unit tests added for tests/test_auto_convert_csv.py
 - QA: pytest -q passed
+
+### 2025-07-27
+- [Patch v6.9.46] Allow env override for adaptive signal quantile
+- New/Updated unit tests added for tests/test_env_utils.py
+- QA: pytest -q passed (358 tests)

--- a/src/config.py
+++ b/src/config.py
@@ -820,7 +820,9 @@ MIN_SIGNAL_SCORE_ENTRY = get_env_float(
 )
 # [Patch v5.3.9] Adaptive threshold settings
 ADAPTIVE_SIGNAL_SCORE_WINDOW = 1000   # Bars used for quantile calculation
-ADAPTIVE_SIGNAL_SCORE_QUANTILE = 0.4  # [Patch v5.7.1] Lower quantile (40th)
+ADAPTIVE_SIGNAL_SCORE_QUANTILE = get_env_float(
+    "ADAPTIVE_SIGNAL_SCORE_QUANTILE", 0.4
+)
 MIN_SIGNAL_SCORE_ENTRY_MIN = 0.3      # Clamp lower bound
 MIN_SIGNAL_SCORE_ENTRY_MAX = 3.0      # Clamp upper bound
 MIN_SIGNAL_SCORE_ENTRY = max(MIN_SIGNAL_SCORE_ENTRY_MIN, min(MIN_SIGNAL_SCORE_ENTRY_MAX, MIN_SIGNAL_SCORE_ENTRY))

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -55,6 +55,16 @@ def test_min_signal_score_env(monkeypatch):
     importlib.reload(cfg)
 
 
+def test_adaptive_signal_quantile_env(monkeypatch):
+    monkeypatch.setenv("ADAPTIVE_SIGNAL_SCORE_QUANTILE", "0.25")
+    if 'src.config' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'src.config', raising=False)
+    cfg = importlib.import_module('src.config')
+    assert cfg.ADAPTIVE_SIGNAL_SCORE_QUANTILE == 0.25
+    monkeypatch.delenv('ADAPTIVE_SIGNAL_SCORE_QUANTILE', raising=False)
+    importlib.reload(cfg)
+
+
 def test_meta_threshold_env(monkeypatch):
     monkeypatch.setenv("META_MIN_PROBA_THRESH", "0.4")
     monkeypatch.setenv("REENTRY_MIN_PROBA_THRESH", "0.35")


### PR DESCRIPTION
## Summary
- allow environment variable for `ADAPTIVE_SIGNAL_SCORE_QUANTILE`
- test env override for adaptive signal threshold
- document change in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee8784dcc8325ae2550d526dee4b8