### PR TITLE
Add indexes to trade_events table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2025-07-28
+- [Patch v6.9.47] Add indexes to trade_events table
+- New/Updated unit tests added for tests/test_event_etl.py::test_init_db_creates_indexes
+- QA: pytest -q passed (existing tests)
+
 ### 2025-07-26
 - [Patch v6.9.45] Add full_pipeline CLI command to ProjectP
 - New/Updated unit tests added for tests/test_projectp_cli.py::test_run_mode_full_pipeline

--- a/src/event_etl.py
+++ b/src/event_etl.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     String,
     DateTime,
     MetaData,
+    Index,
     create_engine,
 )
 from sqlalchemy.engine import Engine
@@ -30,6 +31,8 @@ trade_events = Table(
     Column("event_type", String(32), nullable=False),
     Column("detail", String, nullable=True),
 )
+Index("ix_trade_events_timestamp", trade_events.c.timestamp)
+Index("ix_trade_events_event_type", trade_events.c.event_type)
 
 
 def init_db(engine: Engine) -> None:

--- a/tests/test_event_etl.py
+++ b/tests/test_event_etl.py
@@ -1,5 +1,5 @@
 import os
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, text, inspect
 
 from src.event_etl import init_db, ingest_log_to_db
 
@@ -36,3 +36,15 @@ def test_ingest_log_to_db_empty(tmp_path):
     with engine.connect() as conn:
         result = conn.execute(text("SELECT COUNT(*) FROM trade_events")).scalar()
     assert result == 0
+
+
+def test_init_db_creates_indexes(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    engine = create_engine(f"sqlite:///{db_path}")
+    init_db(engine)
+    inspector = inspect(engine)
+    indexes = inspector.get_indexes("trade_events")
+    names = {idx["name"] for idx in indexes}
+    assert "ix_trade_events_timestamp" in names
+    assert "ix_trade_events_event_type" in names
+


### PR DESCRIPTION
## Summary
- index `timestamp` and `event_type` columns in `trade_events`
- test for index creation
- document patch in CHANGELOG

## Testing
- `pytest tests/test_event_etl.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684eeb82535883259a893bb3b89ca5c9