### PR TITLE
Fix DatetimeIndex in pipeline backtest stage

### DIFF
--- a/src/pipeline_helpers.py
+++ b/src/pipeline_helpers.py
@@ -57,6 +57,11 @@ def run_pipeline_stage(stage: str):
                 df = main_mod.load_validated_csv(DATA_FILE_PATH_M1, "M1")
         else:
             df = main_mod.load_validated_csv(DATA_FILE_PATH_M1, "M1")
+
+        if not isinstance(df.index, pd.DatetimeIndex):
+            df = main_mod.prepare_datetime(df, "M1")
+            df = df[df.index.notna()].sort_index()
+
         run_backtest_simulation_v34(
             df, label="WFV", initial_capital_segment=INITIAL_CAPITAL
         )


### PR DESCRIPTION
## Summary
- ensure index is DatetimeIndex before running backtest in pipeline_helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef9dd261c8325b03dd369c40c878a