### PR TITLE
Improve ProjectP CLI behavior for tests

### DIFF
--- a/ProjectP.py
+++ b/ProjectP.py
@@ -490,6 +490,9 @@ def main():
         selected = interactive_menu()
         if not selected or selected == "exit":
             return
+        if selected == "full_pipeline":
+            run_full_pipeline()
+            return
         args.mode = selected
 
     if args.auto_convert:
@@ -535,7 +538,7 @@ def _script_main():
         sys.exit(0)
     import main as pipeline_main
     pipeline_main.main()
-    sys.exit(0)
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1599,7 +1599,7 @@ def validate_csv_data(df, required_cols=None):
 
     subset = [c for c in price_cols + [vol_col] if c in sample.columns]
     if subset and sample[subset].isna().any().any():
-        raise ValueError("Missing values detected in price columns")
+        raise TypeError("Missing values detected in price columns")
 
     return df
 


### PR DESCRIPTION
## Summary
- avoid double run when menu selects full pipeline
- only exit in auto-convert mode in `_script_main`
- raise `TypeError` when CSV price columns have missing values

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684f124b73208325be37f8b655719574